### PR TITLE
chore(test): fix sass compilation in WTR config

### DIFF
--- a/packages/extended/package.json
+++ b/packages/extended/package.json
@@ -107,6 +107,7 @@
     "@ungap/structured-clone": "^1.3.0",
     "@wc-toolkit/jsdoc-tags": "^1.1.0",
     "@web/dev-server-esbuild": "catalog:",
+    "@web/dev-server-rollup": "catalog:",
     "@web/test-runner": "catalog:",
     "@web/test-runner-commands": "catalog:",
     "@web/test-runner-junit-reporter": "catalog:",

--- a/packages/extended/src/lib/quantity-field/quantity-field.scss
+++ b/packages/extended/src/lib/quantity-field/quantity-field.scss
@@ -8,7 +8,7 @@
 //
 
 :host {
-  display: inline block;
+  display: inline-block;
 }
 
 //

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ catalogs:
     '@web/dev-server-esbuild':
       specifier: 1.0.4
       version: 1.0.4
+    '@web/dev-server-rollup':
+      specifier: 0.6.4
+      version: 0.6.4
     '@web/test-runner':
       specifier: 0.20.0
       version: 0.20.0
@@ -335,6 +338,9 @@ importers:
       '@web/dev-server-esbuild':
         specifier: 'catalog:'
         version: 1.0.4
+      '@web/dev-server-rollup':
+        specifier: 'catalog:'
+        version: 0.6.4
       '@web/test-runner':
         specifier: 'catalog:'
         version: 0.20.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,6 +27,7 @@ catalog:
   '@types/sinon': 17.0.4
   '@typescript-eslint/eslint-plugin': 7.18.0
   '@web/dev-server-esbuild': 1.0.4
+  '@web/dev-server-rollup': 0.6.4
   '@web/test-runner': 0.20.0
   '@web/test-runner-commands': 0.9.0
   '@web/test-runner-junit-reporter': 0.8.0


### PR DESCRIPTION
Sass files were not being compiled in the WTR testing environment. This change adds a plugin to compile imported Sass files on the fly.