### PR TITLE
chore: update git hooks

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-npx --no-install commitlint --edit "$1"
+pnpm exec commitlint --edit "$1"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,0 @@
-pnpm run lint


### PR DESCRIPTION
- Removing pre-push hook (we lint the staged files on commit already)
- Use `pnpm exec` instead of `npx` for commit-msg hook