### PR TITLE
docs: add workaround to auto-close native dialogs between pages

### DIFF
--- a/packages/extended/.storybook/addons/decorator-dialog-closer/preset-preview-decorator-dialog-closer.mjs
+++ b/packages/extended/.storybook/addons/decorator-dialog-closer/preset-preview-decorator-dialog-closer.mjs
@@ -1,0 +1,10 @@
+import { addons } from '@storybook/preview-api';
+import { DOCS_RENDERED } from '@storybook/core-events';
+import { deepQuerySelectorAll } from '@tylertech/forge-core';
+
+addons.getChannel().on(DOCS_RENDERED, () => {
+  // This is a workaround for a Storybook issue where <dialog> elements do not close when navigating to the docs page
+  // Related: https://github.com/storybookjs/storybook/issues/16949
+  const dialogs = deepQuerySelectorAll(document.body, 'dialog[open]');
+  dialogs.forEach(dialog => dialog.close());
+});

--- a/packages/extended/.storybook/addons/decorator-dialog-closer/preset.js
+++ b/packages/extended/.storybook/addons/decorator-dialog-closer/preset.js
@@ -1,0 +1,5 @@
+function previewAnnotations(entry = []) {
+  return [...entry, require.resolve('./preset-preview-decorator-dialog-closer.mjs')];
+}
+
+module.exports = { previewAnnotations };

--- a/packages/extended/.storybook/main.ts
+++ b/packages/extended/.storybook/main.ts
@@ -20,7 +20,8 @@ const config: StorybookConfig = {
           }
         }
       }
-    }
+    },
+    './addons/decorator-dialog-closer'
   ],
   staticDirs: ['../src/stories/assets'],
   framework: {


### PR DESCRIPTION
Workaround to automatically close any open `<dialog>` elements when switching between demos and docs pages.