### PR TITLE
chore(responsive-toolbar): fixed some jankiness with the responsive toolbar story demo

### DIFF
--- a/packages/extended/src/stories/components/responsive-toolbar/ResponsiveToolbar.stories.ts
+++ b/packages/extended/src/stories/components/responsive-toolbar/ResponsiveToolbar.stories.ts
@@ -47,7 +47,7 @@ const meta = {
                 <forge-icon-button aria-label="Icon button demo" slot="before-start">
                   <forge-icon name="arrow_back" external></forge-icon>
                 </forge-icon-button>
-                <div slot="start" class="forge-typography--heading4">${args.title}</div>
+                <div slot="start" class="title forge-typography--heading4">${args.title}</div>
                 <forge-stack inline alignment="center" slot="end-large">
                   ${options.map(
                     item => html` <forge-button variant=${ifDefined(item.variant)}>${item.label}</forge-button> `
@@ -79,6 +79,10 @@ const meta = {
       </forge-split-view>
 
       <style>
+        .title {
+          white-space: nowrap;
+        }
+
         forge-split-view {
           height: 300px;
         }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: [N]
- Docs have been added/updated: [N]
- Does this PR introduce a breaking change? [Y]
- I have linked any related GitHub issues to be closed when this PR is merged? [N]

## Describe the new behavior?
Storybook demo title was a big janky when resizing the demo
