### PR TITLE
Update confirmation dialog backdrop click

### DIFF
--- a/.changeset/rare-baths-rush.md
+++ b/.changeset/rare-baths-rush.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge-extended': minor
+---
+
+Removed the ability to close the confirmation dialog by clicking on the backdrop by default

--- a/packages/extended/custom-elements.json
+++ b/packages/extended/custom-elements.json
@@ -855,19 +855,19 @@
     },
     "ConfirmationDialogActionEventType": {
       "path": "src/lib/confirmation-dialog/confirmation-dialog.ts",
-      "lineNumber": 27
+      "lineNumber": 28
     },
     "ConfirmationDialogActionEventData": {
       "path": "src/lib/confirmation-dialog/confirmation-dialog.ts",
-      "lineNumber": 29
+      "lineNumber": 30
     },
     "ConfirmationDialogProperties": {
       "path": "src/lib/confirmation-dialog/confirmation-dialog.ts",
-      "lineNumber": 34
+      "lineNumber": 35
     },
     "ConfirmationDialogComponent": {
       "path": "src/lib/confirmation-dialog/confirmation-dialog.ts",
-      "lineNumber": 54
+      "lineNumber": 55
     },
     "QuantityFieldComponent": {
       "path": "src/lib/quantity-field/quantity-field.ts",

--- a/packages/extended/custom-elements.json
+++ b/packages/extended/custom-elements.json
@@ -853,7 +853,7 @@
       "path": "src/lib/busy-indicator/busy-indicator.ts",
       "lineNumber": 39
     },
-    "ConfirmationDialogActionEventType": {
+    "ConfirmationDialogActionEventReason": {
       "path": "src/lib/confirmation-dialog/confirmation-dialog.ts",
       "lineNumber": 28
     },

--- a/packages/extended/src/lib/confirmation-dialog/confirmation-dialog.test.ts
+++ b/packages/extended/src/lib/confirmation-dialog/confirmation-dialog.test.ts
@@ -2,7 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import { fixture, html } from '@open-wc/testing';
 import { ConfirmationDialogComponent } from './confirmation-dialog';
 import sinon from 'sinon';
-import { ButtonComponent, IBackdropComponent, ICircularProgressComponent, IDialogComponent } from '@tylertech/forge';
+import { ButtonComponent, ICircularProgressComponent, IDialogComponent } from '@tylertech/forge';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { sendMouse } from '@web/test-runner-commands';
 

--- a/packages/extended/src/lib/confirmation-dialog/confirmation-dialog.test.ts
+++ b/packages/extended/src/lib/confirmation-dialog/confirmation-dialog.test.ts
@@ -2,7 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import { fixture, html } from '@open-wc/testing';
 import { ConfirmationDialogComponent } from './confirmation-dialog';
 import sinon from 'sinon';
-import { ButtonComponent, ICircularProgressComponent, IDialogComponent } from '@tylertech/forge';
+import { ButtonComponent, IBackdropComponent, ICircularProgressComponent, IDialogComponent } from '@tylertech/forge';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { sendMouse } from '@web/test-runner-commands';
 
@@ -189,6 +189,15 @@ describe('ConfirmationDialog', () => {
 
     expect(spy).to.have.been.calledOnce;
     expect(harness.el.open).to.be.false;
+  });
+
+  it('should not close when the backdrop is clicked', async () => {
+    const harness = await createFixture({ open: true });
+
+    expect(harness.el.open).to.be.true;
+    await sendMouse({ type: 'click', position: [0, 0], button: 'left' });
+
+    expect(harness.el.open).to.be.true;
   });
 
   it('should set accessible label from slotted title', async () => {

--- a/packages/extended/src/lib/confirmation-dialog/confirmation-dialog.ts
+++ b/packages/extended/src/lib/confirmation-dialog/confirmation-dialog.ts
@@ -153,7 +153,7 @@ export class ConfirmationDialogComponent extends LitElement implements Confirmat
           variant="outlined"
           ?disabled=${this.isBusy}
           id="secondary-button"
-          @click=${() => this._onAction(false)}>
+          @click=${() => this._onAction(false, 'action')}>
           ${this.#secondaryButtonSlot}
         </forge-button>`,
       () => html`${this.#secondaryButtonSlot}`
@@ -166,7 +166,7 @@ export class ConfirmationDialogComponent extends LitElement implements Confirmat
       variant="raised"
       id="primary-button"
       style=${styleMap({ minWidth: this.#primaryButtonWidth })}
-      @click=${() => this._onAction(true)}>
+      @click=${() => this._onAction(true, 'action')}>
       ${this.#primaryButtonSlot}
     </forge-button>`;
   }
@@ -209,7 +209,6 @@ export class ConfirmationDialogComponent extends LitElement implements Confirmat
     type: ConfirmationDialogActionEventType = 'action',
     evt?: CustomEvent<IDialogBeforeCloseEventData>
   ): void {
-    const reason = evt?.detail?.reason;
     const actionEvent = new CustomEvent<ConfirmationDialogActionEventData>('forge-confirmation-dialog-action', {
       bubbles: true,
       composed: true,
@@ -222,7 +221,7 @@ export class ConfirmationDialogComponent extends LitElement implements Confirmat
 
     this.dispatchEvent(actionEvent);
 
-    if (evt && evt.detail?.reason === 'backdrop') {
+    if (evt?.detail?.reason === 'backdrop' && type === 'light-dismiss') {
       evt.preventDefault();
       return;
     }

--- a/packages/extended/src/lib/confirmation-dialog/confirmation-dialog.ts
+++ b/packages/extended/src/lib/confirmation-dialog/confirmation-dialog.ts
@@ -153,7 +153,7 @@ export class ConfirmationDialogComponent extends LitElement implements Confirmat
           variant="outlined"
           ?disabled=${this.isBusy}
           id="secondary-button"
-          @click=${() => this._onAction(false, 'action')}>
+          @click=${() => this._onAction(false)}>
           ${this.#secondaryButtonSlot}
         </forge-button>`,
       () => html`${this.#secondaryButtonSlot}`
@@ -166,7 +166,7 @@ export class ConfirmationDialogComponent extends LitElement implements Confirmat
       variant="raised"
       id="primary-button"
       style=${styleMap({ minWidth: this.#primaryButtonWidth })}
-      @click=${() => this._onAction(true, 'action')}>
+      @click=${() => this._onAction(true)}>
       ${this.#primaryButtonSlot}
     </forge-button>`;
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: [Y]
- Docs have been added/updated: [N]
- Does this PR introduce a breaking change? [N]
- I have linked any related GitHub issues to be closed when this PR is merged? [N]

## Describe the new behavior?
Teams have requested that the confirmation dialog not be closed when clicking on the backdrop, but still allow for the escape to close it
