### PR TITLE
feat(structured-card): update footer layout behavior

### DIFF
--- a/.changeset/green-clubs-enjoy.md
+++ b/.changeset/green-clubs-enjoy.md
@@ -1,0 +1,7 @@
+---
+'@tylertech/forge-extended': minor
+---
+
+feat(structured-card): more responsive footer
+
+- modified the footer layout to use flex and wrap when needed

--- a/.changeset/green-clubs-enjoy.md
+++ b/.changeset/green-clubs-enjoy.md
@@ -2,6 +2,6 @@
 '@tylertech/forge-extended': patch
 ---
 
-feat(structured-card): more responsive footer
+fix(structured-card): more responsive footer
 
 - modified the footer layout to use flex and wrap when needed

--- a/.changeset/green-clubs-enjoy.md
+++ b/.changeset/green-clubs-enjoy.md
@@ -1,5 +1,5 @@
 ---
-'@tylertech/forge-extended': minor
+'@tylertech/forge-extended': patch
 ---
 
 feat(structured-card): more responsive footer

--- a/packages/extended/custom-elements.json
+++ b/packages/extended/custom-elements.json
@@ -190,335 +190,6 @@
     },
     {
       "kind": "javascript-module",
-      "path": "src/lib/busy-indicator/busy-indicator.ts",
-      "declarations": [
-        {
-          "kind": "variable",
-          "name": "BusyIndicatorComponentTagName",
-          "type": {
-            "text": "keyof HTMLElementTagNameMap"
-          },
-          "default": "'forge-busy-indicator'"
-        },
-        {
-          "kind": "class",
-          "description": "",
-          "name": "BusyIndicatorComponent",
-          "slots": [
-            {
-              "description": "The title text to display.",
-              "name": "title"
-            },
-            {
-              "description": "The message to display.",
-              "name": "message"
-            },
-            {
-              "description": "The text for the cancel button.",
-              "name": "cancel-text"
-            }
-          ],
-          "members": [
-            {
-              "kind": "field",
-              "name": "open",
-              "type": {
-                "text": "boolean"
-              },
-              "privacy": "public",
-              "default": "false",
-              "description": "Indicates whether the busy indicator is open.",
-              "attribute": "open"
-            },
-            {
-              "kind": "field",
-              "name": "mode",
-              "type": {
-                "text": "BusyIndicatorMode"
-              },
-              "privacy": "public",
-              "default": "'fullscreen'",
-              "description": "Whether the busy indicator is fullscreen or inline.",
-              "attribute": "mode"
-            },
-            {
-              "kind": "field",
-              "name": "titleText",
-              "type": {
-                "text": "string | undefined"
-              },
-              "privacy": "public",
-              "description": "The title text to display.",
-              "attribute": "title-text"
-            },
-            {
-              "kind": "field",
-              "name": "headingLevel",
-              "type": {
-                "text": "HeadingLevel"
-              },
-              "privacy": "public",
-              "default": "1",
-              "description": "The heading level for the title.",
-              "attribute": "heading-level"
-            },
-            {
-              "kind": "field",
-              "name": "message",
-              "type": {
-                "text": "string | undefined"
-              },
-              "privacy": "public",
-              "description": "The message to display.",
-              "attribute": "message"
-            },
-            {
-              "kind": "field",
-              "name": "label",
-              "type": {
-                "text": "string | undefined"
-              },
-              "privacy": "public",
-              "description": "The accessible label for dialog.",
-              "attribute": "label"
-            },
-            {
-              "kind": "field",
-              "name": "description",
-              "type": {
-                "text": "string | undefined"
-              },
-              "privacy": "public",
-              "description": "The accessible description for dialog.",
-              "attribute": "description"
-            },
-            {
-              "kind": "field",
-              "name": "cancelable",
-              "type": {
-                "text": "boolean"
-              },
-              "privacy": "public",
-              "default": "false",
-              "description": "Indicates whether the cancel button is displayed.",
-              "attribute": "cancelable"
-            },
-            {
-              "kind": "field",
-              "name": "variant",
-              "type": {
-                "text": "BusyIndicatorVariant"
-              },
-              "privacy": "public",
-              "default": "'spinner'",
-              "description": "The variant of the busy indicator.\n- `spinner` (default): displays a spinner.\n- `progress`: displays a progress bar.\n- `message-only`: No progress indicator is displayed.",
-              "attribute": "variant"
-            },
-            {
-              "kind": "field",
-              "name": "determinate",
-              "type": {
-                "text": "boolean"
-              },
-              "privacy": "public",
-              "default": "false",
-              "description": "Indicates whether the loading indicator is determinate.",
-              "attribute": "determinate"
-            },
-            {
-              "kind": "field",
-              "name": "progress",
-              "type": {
-                "text": "number"
-              },
-              "privacy": "public",
-              "default": "0",
-              "description": "The progress amount for the progress bar.",
-              "attribute": "progress"
-            },
-            {
-              "kind": "field",
-              "name": "buffer",
-              "type": {
-                "text": "number"
-              },
-              "privacy": "public",
-              "default": "0",
-              "description": "The buffer amount for the progress bar.",
-              "attribute": "buffer"
-            },
-            {
-              "kind": "field",
-              "name": "transparent",
-              "type": {
-                "text": "boolean"
-              },
-              "privacy": "public",
-              "default": "false",
-              "description": "Indicates whether the busy indicator surface should be transparent (no background or elevation).",
-              "attribute": "transparent"
-            }
-          ],
-          "events": [
-            {
-              "type": {
-                "text": "CustomEvent<void>"
-              },
-              "description": "Fired when the cancel button is clicked.",
-              "name": "forge-busy-indicator-cancel"
-            }
-          ],
-          "attributes": [
-            {
-              "name": "open",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Indicates whether the busy indicator is open.",
-              "fieldName": "open"
-            },
-            {
-              "name": "mode",
-              "type": {
-                "text": "BusyIndicatorMode"
-              },
-              "default": "'fullscreen'",
-              "description": "Whether the busy indicator is fullscreen or inline.",
-              "fieldName": "mode"
-            },
-            {
-              "name": "title-text",
-              "type": {
-                "text": "string | undefined"
-              },
-              "description": "The title text to display.",
-              "fieldName": "titleText"
-            },
-            {
-              "name": "heading-level",
-              "type": {
-                "text": "HeadingLevel"
-              },
-              "default": "1",
-              "description": "The heading level for the title.",
-              "fieldName": "headingLevel"
-            },
-            {
-              "name": "message",
-              "type": {
-                "text": "string | undefined"
-              },
-              "description": "The message to display.",
-              "fieldName": "message"
-            },
-            {
-              "name": "label",
-              "type": {
-                "text": "string | undefined"
-              },
-              "description": "The accessible label for dialog.",
-              "fieldName": "label"
-            },
-            {
-              "name": "description",
-              "type": {
-                "text": "string | undefined"
-              },
-              "description": "The accessible description for dialog.",
-              "fieldName": "description"
-            },
-            {
-              "name": "cancelable",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Indicates whether the cancel button is displayed.",
-              "fieldName": "cancelable"
-            },
-            {
-              "name": "variant",
-              "type": {
-                "text": "BusyIndicatorVariant"
-              },
-              "default": "'spinner'",
-              "description": "The variant of the busy indicator.\n- `spinner` (default): displays a spinner.\n- `progress`: displays a progress bar.\n- `message-only`: No progress indicator is displayed.",
-              "fieldName": "variant"
-            },
-            {
-              "name": "determinate",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Indicates whether the loading indicator is determinate.",
-              "fieldName": "determinate"
-            },
-            {
-              "name": "progress",
-              "type": {
-                "text": "number"
-              },
-              "default": "0",
-              "description": "The progress amount for the progress bar.",
-              "fieldName": "progress"
-            },
-            {
-              "name": "buffer",
-              "type": {
-                "text": "number"
-              },
-              "default": "0",
-              "description": "The buffer amount for the progress bar.",
-              "fieldName": "buffer"
-            },
-            {
-              "name": "transparent",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Indicates whether the busy indicator surface should be transparent (no background or elevation).",
-              "fieldName": "transparent"
-            }
-          ],
-          "superclass": {
-            "name": "LitElement",
-            "package": "lit"
-          },
-          "tagName": "forge-busy-indicator",
-          "customElement": true
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "BusyIndicatorComponentTagName",
-          "declaration": {
-            "name": "BusyIndicatorComponentTagName",
-            "module": "src/lib/busy-indicator/busy-indicator.ts"
-          }
-        },
-        {
-          "kind": "js",
-          "name": "BusyIndicatorComponent",
-          "declaration": {
-            "name": "BusyIndicatorComponent",
-            "module": "src/lib/busy-indicator/busy-indicator.ts"
-          }
-        },
-        {
-          "kind": "custom-element-definition",
-          "declaration": {
-            "name": "BusyIndicatorComponent",
-            "module": "src/lib/busy-indicator/busy-indicator.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
       "path": "src/lib/app-layout/app-layout.ts",
       "declarations": [
         {
@@ -990,6 +661,335 @@
     },
     {
       "kind": "javascript-module",
+      "path": "src/lib/busy-indicator/busy-indicator.ts",
+      "declarations": [
+        {
+          "kind": "variable",
+          "name": "BusyIndicatorComponentTagName",
+          "type": {
+            "text": "keyof HTMLElementTagNameMap"
+          },
+          "default": "'forge-busy-indicator'"
+        },
+        {
+          "kind": "class",
+          "description": "",
+          "name": "BusyIndicatorComponent",
+          "slots": [
+            {
+              "description": "The title text to display.",
+              "name": "title"
+            },
+            {
+              "description": "The message to display.",
+              "name": "message"
+            },
+            {
+              "description": "The text for the cancel button.",
+              "name": "cancel-text"
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "open",
+              "type": {
+                "text": "boolean"
+              },
+              "privacy": "public",
+              "default": "false",
+              "description": "Indicates whether the busy indicator is open.",
+              "attribute": "open"
+            },
+            {
+              "kind": "field",
+              "name": "mode",
+              "type": {
+                "text": "BusyIndicatorMode"
+              },
+              "privacy": "public",
+              "default": "'fullscreen'",
+              "description": "Whether the busy indicator is fullscreen or inline.",
+              "attribute": "mode"
+            },
+            {
+              "kind": "field",
+              "name": "titleText",
+              "type": {
+                "text": "string | undefined"
+              },
+              "privacy": "public",
+              "description": "The title text to display.",
+              "attribute": "title-text"
+            },
+            {
+              "kind": "field",
+              "name": "headingLevel",
+              "type": {
+                "text": "HeadingLevel"
+              },
+              "privacy": "public",
+              "default": "1",
+              "description": "The heading level for the title.",
+              "attribute": "heading-level"
+            },
+            {
+              "kind": "field",
+              "name": "message",
+              "type": {
+                "text": "string | undefined"
+              },
+              "privacy": "public",
+              "description": "The message to display.",
+              "attribute": "message"
+            },
+            {
+              "kind": "field",
+              "name": "label",
+              "type": {
+                "text": "string | undefined"
+              },
+              "privacy": "public",
+              "description": "The accessible label for dialog.",
+              "attribute": "label"
+            },
+            {
+              "kind": "field",
+              "name": "description",
+              "type": {
+                "text": "string | undefined"
+              },
+              "privacy": "public",
+              "description": "The accessible description for dialog.",
+              "attribute": "description"
+            },
+            {
+              "kind": "field",
+              "name": "cancelable",
+              "type": {
+                "text": "boolean"
+              },
+              "privacy": "public",
+              "default": "false",
+              "description": "Indicates whether the cancel button is displayed.",
+              "attribute": "cancelable"
+            },
+            {
+              "kind": "field",
+              "name": "variant",
+              "type": {
+                "text": "BusyIndicatorVariant"
+              },
+              "privacy": "public",
+              "default": "'spinner'",
+              "description": "The variant of the busy indicator.\n- `spinner` (default): displays a spinner.\n- `progress`: displays a progress bar.\n- `message-only`: No progress indicator is displayed.",
+              "attribute": "variant"
+            },
+            {
+              "kind": "field",
+              "name": "determinate",
+              "type": {
+                "text": "boolean"
+              },
+              "privacy": "public",
+              "default": "false",
+              "description": "Indicates whether the loading indicator is determinate.",
+              "attribute": "determinate"
+            },
+            {
+              "kind": "field",
+              "name": "progress",
+              "type": {
+                "text": "number"
+              },
+              "privacy": "public",
+              "default": "0",
+              "description": "The progress amount for the progress bar.",
+              "attribute": "progress"
+            },
+            {
+              "kind": "field",
+              "name": "buffer",
+              "type": {
+                "text": "number"
+              },
+              "privacy": "public",
+              "default": "0",
+              "description": "The buffer amount for the progress bar.",
+              "attribute": "buffer"
+            },
+            {
+              "kind": "field",
+              "name": "transparent",
+              "type": {
+                "text": "boolean"
+              },
+              "privacy": "public",
+              "default": "false",
+              "description": "Indicates whether the busy indicator surface should be transparent (no background or elevation).",
+              "attribute": "transparent"
+            }
+          ],
+          "events": [
+            {
+              "type": {
+                "text": "CustomEvent<void>"
+              },
+              "description": "Fired when the cancel button is clicked.",
+              "name": "forge-busy-indicator-cancel"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "open",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Indicates whether the busy indicator is open.",
+              "fieldName": "open"
+            },
+            {
+              "name": "mode",
+              "type": {
+                "text": "BusyIndicatorMode"
+              },
+              "default": "'fullscreen'",
+              "description": "Whether the busy indicator is fullscreen or inline.",
+              "fieldName": "mode"
+            },
+            {
+              "name": "title-text",
+              "type": {
+                "text": "string | undefined"
+              },
+              "description": "The title text to display.",
+              "fieldName": "titleText"
+            },
+            {
+              "name": "heading-level",
+              "type": {
+                "text": "HeadingLevel"
+              },
+              "default": "1",
+              "description": "The heading level for the title.",
+              "fieldName": "headingLevel"
+            },
+            {
+              "name": "message",
+              "type": {
+                "text": "string | undefined"
+              },
+              "description": "The message to display.",
+              "fieldName": "message"
+            },
+            {
+              "name": "label",
+              "type": {
+                "text": "string | undefined"
+              },
+              "description": "The accessible label for dialog.",
+              "fieldName": "label"
+            },
+            {
+              "name": "description",
+              "type": {
+                "text": "string | undefined"
+              },
+              "description": "The accessible description for dialog.",
+              "fieldName": "description"
+            },
+            {
+              "name": "cancelable",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Indicates whether the cancel button is displayed.",
+              "fieldName": "cancelable"
+            },
+            {
+              "name": "variant",
+              "type": {
+                "text": "BusyIndicatorVariant"
+              },
+              "default": "'spinner'",
+              "description": "The variant of the busy indicator.\n- `spinner` (default): displays a spinner.\n- `progress`: displays a progress bar.\n- `message-only`: No progress indicator is displayed.",
+              "fieldName": "variant"
+            },
+            {
+              "name": "determinate",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Indicates whether the loading indicator is determinate.",
+              "fieldName": "determinate"
+            },
+            {
+              "name": "progress",
+              "type": {
+                "text": "number"
+              },
+              "default": "0",
+              "description": "The progress amount for the progress bar.",
+              "fieldName": "progress"
+            },
+            {
+              "name": "buffer",
+              "type": {
+                "text": "number"
+              },
+              "default": "0",
+              "description": "The buffer amount for the progress bar.",
+              "fieldName": "buffer"
+            },
+            {
+              "name": "transparent",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Indicates whether the busy indicator surface should be transparent (no background or elevation).",
+              "fieldName": "transparent"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "forge-busy-indicator",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "BusyIndicatorComponentTagName",
+          "declaration": {
+            "name": "BusyIndicatorComponentTagName",
+            "module": "src/lib/busy-indicator/busy-indicator.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "BusyIndicatorComponent",
+          "declaration": {
+            "name": "BusyIndicatorComponent",
+            "module": "src/lib/busy-indicator/busy-indicator.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "declaration": {
+            "name": "BusyIndicatorComponent",
+            "module": "src/lib/busy-indicator/busy-indicator.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "src/lib/count-card/count-card.ts",
       "declarations": [
         {
@@ -1186,6 +1186,119 @@
     },
     {
       "kind": "javascript-module",
+      "path": "src/lib/multi-select-header/multi-select-header.ts",
+      "declarations": [
+        {
+          "kind": "variable",
+          "name": "MultiSelectHeaderComponentTagName",
+          "type": {
+            "text": "keyof HTMLElementTagNameMap"
+          },
+          "default": "'forge-multi-select-header'"
+        },
+        {
+          "kind": "class",
+          "description": "",
+          "name": "MultiSelectHeaderComponent",
+          "slots": [
+            {
+              "description": "Text content for the select-all button",
+              "name": "select-all-button-text"
+            },
+            {
+              "description": "Action buttons (maps to the toolbar end slot)",
+              "name": "actions"
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "text",
+              "type": {
+                "text": "string"
+              },
+              "privacy": "public",
+              "default": "''",
+              "description": "The text to display in the header (typically showing selection count)",
+              "attribute": "text"
+            },
+            {
+              "kind": "field",
+              "name": "noBorder",
+              "type": {
+                "text": "boolean"
+              },
+              "privacy": "public",
+              "default": "true",
+              "description": "Hides the bottom border",
+              "attribute": "no-border"
+            }
+          ],
+          "events": [
+            {
+              "type": {
+                "text": "CustomEvent"
+              },
+              "description": "Fired when the select-all button is clicked",
+              "name": "forge-multi-select-header-select-all"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "text",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "The text to display in the header (typically showing selection count)",
+              "fieldName": "text"
+            },
+            {
+              "name": "no-border",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "true",
+              "description": "Hides the bottom border",
+              "fieldName": "noBorder"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "forge-multi-select-header",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "MultiSelectHeaderComponentTagName",
+          "declaration": {
+            "name": "MultiSelectHeaderComponentTagName",
+            "module": "src/lib/multi-select-header/multi-select-header.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "MultiSelectHeaderComponent",
+          "declaration": {
+            "name": "MultiSelectHeaderComponent",
+            "module": "src/lib/multi-select-header/multi-select-header.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "declaration": {
+            "name": "MultiSelectHeaderComponent",
+            "module": "src/lib/multi-select-header/multi-select-header.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "src/lib/quantity-field/quantity-field.ts",
       "declarations": [
         {
@@ -1354,119 +1467,6 @@
           "declaration": {
             "name": "QuantityFieldComponent",
             "module": "src/lib/quantity-field/quantity-field.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/lib/multi-select-header/multi-select-header.ts",
-      "declarations": [
-        {
-          "kind": "variable",
-          "name": "MultiSelectHeaderComponentTagName",
-          "type": {
-            "text": "keyof HTMLElementTagNameMap"
-          },
-          "default": "'forge-multi-select-header'"
-        },
-        {
-          "kind": "class",
-          "description": "",
-          "name": "MultiSelectHeaderComponent",
-          "slots": [
-            {
-              "description": "Text content for the select-all button",
-              "name": "select-all-button-text"
-            },
-            {
-              "description": "Action buttons (maps to the toolbar end slot)",
-              "name": "actions"
-            }
-          ],
-          "members": [
-            {
-              "kind": "field",
-              "name": "text",
-              "type": {
-                "text": "string"
-              },
-              "privacy": "public",
-              "default": "''",
-              "description": "The text to display in the header (typically showing selection count)",
-              "attribute": "text"
-            },
-            {
-              "kind": "field",
-              "name": "noBorder",
-              "type": {
-                "text": "boolean"
-              },
-              "privacy": "public",
-              "default": "true",
-              "description": "Hides the bottom border",
-              "attribute": "no-border"
-            }
-          ],
-          "events": [
-            {
-              "type": {
-                "text": "CustomEvent"
-              },
-              "description": "Fired when the select-all button is clicked",
-              "name": "forge-multi-select-header-select-all"
-            }
-          ],
-          "attributes": [
-            {
-              "name": "text",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "The text to display in the header (typically showing selection count)",
-              "fieldName": "text"
-            },
-            {
-              "name": "no-border",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "true",
-              "description": "Hides the bottom border",
-              "fieldName": "noBorder"
-            }
-          ],
-          "superclass": {
-            "name": "LitElement",
-            "package": "lit"
-          },
-          "tagName": "forge-multi-select-header",
-          "customElement": true
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "MultiSelectHeaderComponentTagName",
-          "declaration": {
-            "name": "MultiSelectHeaderComponentTagName",
-            "module": "src/lib/multi-select-header/multi-select-header.ts"
-          }
-        },
-        {
-          "kind": "js",
-          "name": "MultiSelectHeaderComponent",
-          "declaration": {
-            "name": "MultiSelectHeaderComponent",
-            "module": "src/lib/multi-select-header/multi-select-header.ts"
-          }
-        },
-        {
-          "kind": "custom-element-definition",
-          "declaration": {
-            "name": "MultiSelectHeaderComponent",
-            "module": "src/lib/multi-select-header/multi-select-header.ts"
           }
         }
       ]
@@ -2314,7 +2314,7 @@
       ]
     }
   ],
-  "branchName": "count-card",
+  "branchName": "main",
   "forgeTypes": {
     "AppLauncherOption": {
       "path": "src/lib/app-launcher/app-launcher.ts",
@@ -2327,22 +2327,6 @@
     "AppLauncherComponent": {
       "path": "src/lib/app-launcher/app-launcher.ts",
       "lineNumber": 67
-    },
-    "BusyIndicatorMode": {
-      "path": "src/lib/busy-indicator/busy-indicator.ts",
-      "lineNumber": 26
-    },
-    "BusyIndicatorVariant": {
-      "path": "src/lib/busy-indicator/busy-indicator.ts",
-      "lineNumber": 27
-    },
-    "BusyIndicatorFocusMode": {
-      "path": "src/lib/busy-indicator/busy-indicator.ts",
-      "lineNumber": 28
-    },
-    "BusyIndicatorComponent": {
-      "path": "src/lib/busy-indicator/busy-indicator.ts",
-      "lineNumber": 40
     },
     "AppLayoutBreakpoint": {
       "path": "src/lib/app-layout/app-layout.ts",
@@ -2376,6 +2360,22 @@
       "path": "src/lib/confirmation-dialog/confirmation-dialog.ts",
       "lineNumber": 55
     },
+    "BusyIndicatorMode": {
+      "path": "src/lib/busy-indicator/busy-indicator.ts",
+      "lineNumber": 26
+    },
+    "BusyIndicatorVariant": {
+      "path": "src/lib/busy-indicator/busy-indicator.ts",
+      "lineNumber": 27
+    },
+    "BusyIndicatorFocusMode": {
+      "path": "src/lib/busy-indicator/busy-indicator.ts",
+      "lineNumber": 28
+    },
+    "BusyIndicatorComponent": {
+      "path": "src/lib/busy-indicator/busy-indicator.ts",
+      "lineNumber": 40
+    },
     "CountCardTheme": {
       "path": "src/lib/count-card/count-card.ts",
       "lineNumber": 16
@@ -2384,13 +2384,13 @@
       "path": "src/lib/count-card/count-card.ts",
       "lineNumber": 71
     },
-    "QuantityFieldComponent": {
-      "path": "src/lib/quantity-field/quantity-field.ts",
-      "lineNumber": 35
-    },
     "MultiSelectHeaderComponent": {
       "path": "src/lib/multi-select-header/multi-select-header.ts",
       "lineNumber": 28
+    },
+    "QuantityFieldComponent": {
+      "path": "src/lib/quantity-field/quantity-field.ts",
+      "lineNumber": 35
     },
     "ContentScaffoldComponent": {
       "path": "src/lib/content-scaffold/content-scaffold.ts",

--- a/packages/extended/src/lib/structured-card/structured-card.scss
+++ b/packages/extended/src/lib/structured-card/structured-card.scss
@@ -11,7 +11,7 @@
 :host(:state(body-spacing-none)) {
   forge-content-scaffold {
     --forge-content-scaffold-body-padding-inline: 0;
-    --forge-content-scaffold-footer-full-padding: 0;
+    --forge-content-scaffold-footer-full-padding: #{forge-spacing.variable(small)} #{forge-spacing.variable(medium)};
     --forge-content-scaffold-body-padding-block: 0;
   }
 
@@ -65,17 +65,19 @@ forge-content-scaffold {
 }
 
 .footer-container {
-  display: grid;
-  grid-template-columns: auto 1fr auto;
+  display: flex;
+  justify-content: space-between;
   align-items: center;
-  grid-template-areas: 'start . end';
+  flex-wrap: wrap;
+  column-gap: #{forge-spacing.variable(medium)};
 }
 
 .footer-start-container {
-  grid-area: start;
+  flex: 1;
+  flex-basis: content;
+  justify-content: flex-end;
 }
 
 .footer-actions {
   @include mixins.stack($gap: #{forge-spacing.variable(medium)}, $isInline: true);
-  grid-area: end;
 }

--- a/packages/extended/src/stories/components/structured-card/WithTableAndStartButtons.stories.ts
+++ b/packages/extended/src/stories/components/structured-card/WithTableAndStartButtons.stories.ts
@@ -1,0 +1,71 @@
+import { type Meta, type StoryObj } from '@storybook/web-components-vite';
+import { html } from 'lit';
+import {
+  defineTableComponent,
+  defineIconButtonComponent,
+  defineIconComponent,
+  definePaginatorComponent,
+  defineButtonComponent,
+  IconRegistry,
+  defineStackComponent
+} from '@tylertech/forge';
+import { tylIconFilter, tylIconRefresh, tylIconDownload } from '@tylertech/tyler-icons';
+
+import '$lib/structured-card';
+
+defineTableComponent();
+defineIconButtonComponent();
+defineIconComponent();
+definePaginatorComponent();
+defineButtonComponent();
+defineStackComponent();
+IconRegistry.define([tylIconFilter, tylIconRefresh, tylIconDownload]);
+
+const component = 'forge-structured-card';
+
+const meta = {
+  title: 'Components/Structured Card',
+  component,
+
+  render: () => {
+    const tableData = [
+      { id: 'AST-001', name: 'Dell Latitude 5520', category: 'Laptop', location: 'Building A', status: 'In Use' },
+      { id: 'AST-002', name: 'HP LaserJet Pro', category: 'Printer', location: 'Building B', status: 'Available' },
+      { id: 'AST-003', name: 'Cisco IP Phone 8845', category: 'Phone', location: 'Building A', status: 'In Use' },
+      { id: 'AST-004', name: 'Samsung 27" Monitor', category: 'Monitor', location: 'Building C', status: 'In Repair' },
+      { id: 'AST-005', name: 'Logitech MX Keys', category: 'Keyboard', location: 'Building A', status: 'Available' }
+    ];
+
+    const columnConfigurations = [
+      { property: 'id', header: 'Asset ID' },
+      { property: 'name', header: 'Asset Name' },
+      { property: 'category', header: 'Category' },
+      { property: 'location', header: 'Location' },
+      { property: 'status', header: 'Status' }
+    ];
+
+    return html`
+      <forge-structured-card heading-level="2" body-spacing="none">
+        <div slot="title">Asset Inventory</div>
+        <forge-icon-button aria-label="Refresh data" slot="after-header-actions">
+          <forge-icon name="refresh"></forge-icon>
+        </forge-icon-button>
+        <forge-icon-button aria-label="Download report" slot="after-header-actions">
+          <forge-icon name="download"></forge-icon>
+        </forge-icon-button>
+        <forge-table slot="body" .data=${tableData} .columnConfigurations=${columnConfigurations}></forge-table>
+        <forge-stack slot="footer-start" inline alignment="center" wrap gap="8">
+          <forge-button variant="outlined">Update asset inventory</forge-button>
+          <forge-button variant="outlined">Asset inventory dataset</forge-button>
+        </forge-stack>
+        <forge-paginator slot="footer-primary-action" page-size="5" total="25" page-index="0"></forge-paginator>
+      </forge-structured-card>
+    `;
+  }
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj;
+
+export const WithTableAndStartButtons: Story = {};


### PR DESCRIPTION
Update footer layout behavior to make it render better on smaller devices:

<img width="554" height="555" alt="image" src="https://github.com/user-attachments/assets/2aaf16a6-4b4c-4cd6-be78-0c8710712322" />


## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: [N]
- Docs have been added/updated: [N]
- Does this PR introduce a breaking change? [N]
- I have linked any related GitHub issues to be closed when this PR is merged? [N]

## Describe the new behavior?
Converted the footer from grid to flex and added wrapping. This helps with an uncommon issue of the end slot elements overlapping with the start slot elements
