### PR TITLE
feat(rich-text-editor): 1 of 10 - add sanitization, paste, and markdown utilities

### DIFF
--- a/packages/extended/src/lib/rich-text-editor/extensions/markdown-serializer.ts
+++ b/packages/extended/src/lib/rich-text-editor/extensions/markdown-serializer.ts
@@ -1,0 +1,212 @@
+import type { JSONContent } from '@tiptap/core';
+
+interface MarkAttrs {
+  type: string;
+  attrs?: Record<string, unknown>;
+}
+
+/**
+ * Serializes ProseMirror JSON content to Markdown format.
+ *
+ * Supports all rich text editor features:
+ * - Text formatting: bold, italic, underline, strikethrough, code
+ * - Headings: H1, H2, H3
+ * - Lists: bullet lists, ordered lists
+ * - Links
+ * - Text alignment (converted to HTML comments for preservation)
+ * - Paragraphs and line breaks
+ */
+export class MarkdownSerializer {
+  /**
+   * Converts ProseMirror JSON content to Markdown string.
+   *
+   * @param json - The ProseMirror JSON content from editor.getJSON()
+   * @returns The Markdown string representation
+   */
+  public static serialize(json: JSONContent): string {
+    if (!json || !json.content) {
+      return '';
+    }
+
+    return this.#serializeNodes(json.content);
+  }
+
+  static #serializeNodes(nodes: JSONContent[]): string {
+    return nodes.map(node => this.#serializeNode(node)).join('');
+  }
+
+  static #serializeNode(node: JSONContent): string {
+    switch (node.type) {
+      case 'paragraph':
+        return this.#serializeParagraph(node);
+      case 'heading':
+        return this.#serializeHeading(node);
+      case 'bulletList':
+        return this.#serializeBulletList(node);
+      case 'orderedList':
+        return this.#serializeOrderedList(node);
+      case 'listItem':
+        return this.#serializeListItem(node);
+      case 'text':
+        return this.#serializeText(node);
+      case 'hardBreak':
+        return '  \n'; // Two spaces + newline for hard break in Markdown
+      default: {
+        // Unknown node type - serialize children if present
+        if (node.content) {
+          return this.#serializeNodes(node.content);
+        }
+        return '';
+      }
+    }
+  }
+
+  static #serializeParagraph(node: JSONContent): string {
+    const content = node.content ? this.#serializeNodes(node.content) : '';
+    const alignment = node.attrs?.textAlign;
+
+    // Empty paragraphs
+    if (!content.trim()) {
+      return '\n';
+    }
+
+    // Add alignment as HTML comment if non-default
+    if (alignment && alignment !== 'left' && alignment !== 'start') {
+      return `<!-- align:${alignment} -->\n${content}\n\n`;
+    }
+
+    return `${content}\n\n`;
+  }
+
+  static #serializeHeading(node: JSONContent): string {
+    const level = node.attrs?.level ?? 1;
+    const content = node.content ? this.#serializeNodes(node.content) : '';
+    const hashes = '#'.repeat(level);
+
+    return `${hashes} ${content}\n\n`;
+  }
+
+  static #serializeBulletList(node: JSONContent): string {
+    if (!node.content) {
+      return '';
+    }
+
+    const items = node.content.map(item => this.#serializeBulletListItem(item)).join('');
+    return `${items}\n`;
+  }
+
+  static #serializeOrderedList(node: JSONContent): string {
+    if (!node.content) {
+      return '';
+    }
+
+    const items = node.content.map((item, index) => this.#serializeOrderedListItem(item, index + 1)).join('');
+    return `${items}\n`;
+  }
+
+  static #serializeBulletListItem(node: JSONContent): string {
+    if (node.type !== 'listItem' || !node.content) {
+      return '';
+    }
+
+    const content = this.#serializeListItemContent(node.content);
+    return `- ${content}\n`;
+  }
+
+  static #serializeOrderedListItem(node: JSONContent, itemNumber: number): string {
+    if (node.type !== 'listItem' || !node.content) {
+      return '';
+    }
+
+    const content = this.#serializeListItemContent(node.content);
+    return `${itemNumber}. ${content}\n`;
+  }
+
+  static #serializeListItem(node: JSONContent): string {
+    // This is called for nested list items
+    if (!node.content) {
+      return '';
+    }
+
+    return this.#serializeListItemContent(node.content);
+  }
+
+  static #serializeListItemContent(nodes: JSONContent[]): string {
+    // List items contain paragraphs - we want inline content
+    return nodes
+      .map(node => {
+        if (node.type === 'paragraph') {
+          return node.content ? this.#serializeNodes(node.content) : '';
+        }
+        return this.#serializeNode(node);
+      })
+      .join('');
+  }
+
+  static #serializeText(node: JSONContent): string {
+    const hasCodeMark = node.marks?.some((m: MarkAttrs) => m.type === 'code');
+    // Escape raw text unless it will be wrapped in a code span (backtick context)
+    let text = hasCodeMark ? (node.text ?? '') : this.escape(node.text ?? '');
+
+    // Apply marks in order: bold, italic, underline, strikethrough, code
+    if (node.marks && node.marks.length > 0) {
+      for (const mark of node.marks) {
+        text = this.#applyMark(text, mark as MarkAttrs);
+      }
+    }
+
+    return text;
+  }
+
+  static #applyMark(text: string, mark: MarkAttrs): string {
+    switch (mark.type) {
+      case 'bold': {
+        const trimmed = text.trim();
+        const leading = text.slice(0, text.length - text.trimStart().length);
+        const trailing = text.slice(text.trimEnd().length);
+        return `${leading}**${trimmed}**${trailing}`;
+      }
+      case 'italic':
+        return `*${text}*`;
+      case 'underline': {
+        // Markdown doesn't support underline natively - use HTML
+        return `<u>${text}</u>`;
+      }
+      case 'strike':
+        return `~~${text}~~`;
+      case 'code':
+        return `\`${text}\``;
+      case 'link': {
+        const href = String(mark.attrs?.href ?? '');
+        // Escape parens in href to avoid breaking Markdown link syntax
+        const safeHref = href.replace(/\(/g, '%28').replace(/\)/g, '%29');
+        return `[${text}](${safeHref})`;
+      }
+      default:
+        return text;
+    }
+  }
+
+  /**
+   * Escapes special Markdown characters in text content.
+   * Used for text that should not be interpreted as Markdown.
+   *
+   * @param text - The text to escape
+   * @returns The escaped text
+   */
+  public static escape(text: string): string {
+    // Only escape characters that break inline Markdown structure.
+    // Do NOT escape `.`, `-`, `+`, `!`, `#` — they are only special at line-start
+    // in block contexts, not inline, so escaping them here would corrupt normal text.
+    return text
+      .replace(/\\/g, '\\\\')
+      .replace(/\*/g, '\\*')
+      .replace(/_/g, '\\_')
+      .replace(/`/g, '\\`')
+      .replace(/\[/g, '\\[')
+      .replace(/\]/g, '\\]')
+      .replace(/\(/g, '\\(')
+      .replace(/\)/g, '\\)')
+      .replace(/~/g, '\\~');
+  }
+}

--- a/packages/extended/src/lib/rich-text-editor/extensions/paste-handler.ts
+++ b/packages/extended/src/lib/rich-text-editor/extensions/paste-handler.ts
@@ -1,0 +1,133 @@
+import { Extension } from '@tiptap/core';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
+import { Slice, Fragment, Node as ProseMirrorNode } from '@tiptap/pm/model';
+import { sanitizeHTML } from './sanitize-utils';
+
+export interface PasteHandlerOptions {
+  /**
+   * Whether to allow pasted content to retain formatting.
+   * When false, all pasted content is treated as plain text.
+   */
+  readonly allowPasteFormatting: boolean;
+
+  /**
+   * Whether to allow images to be pasted into the editor.
+   * When false, image elements are stripped from pasted content.
+   */
+  readonly allowPasteImages: boolean;
+}
+
+/**
+ * Extension that provides enhanced paste handling with sanitization and formatting options.
+ *
+ * Features:
+ * - Strip dangerous HTML (scripts, iframes, etc.)
+ * - Control whether formatting is preserved or stripped
+ * - Control whether images are allowed
+ * - Keyboard shortcut (Ctrl/Cmd+Shift+V) for plain text paste
+ */
+export const PasteHandler = Extension.create<PasteHandlerOptions>({
+  name: 'pasteHandler',
+
+  addOptions() {
+    return {
+      allowPasteFormatting: true,
+      allowPasteImages: false
+    };
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      // Ctrl+Shift+V / Cmd+Shift+V for plain text paste
+      'Mod-Shift-v': () => {
+        const { view } = this.editor;
+
+        // Read clipboard — rebuild transaction from current view.state inside .then()
+        // to avoid using stale selection positions captured before the async gap.
+        navigator.clipboard
+          .readText()
+          .then(text => {
+            const { state } = view;
+            const { from, to } = state.selection;
+            const ccExt = this.editor.extensionManager.extensions.find(e => e.name === 'characterCount');
+            const maxLength = ccExt?.options?.limit as number | undefined;
+            if (maxLength) {
+              const currentChars = state.doc.textContent.length - (to - from);
+              const available = maxLength - currentChars;
+              if (available <= 0) {
+                return;
+              }
+              text = text.slice(0, available);
+            }
+            const tr = state.tr.replaceWith(from, to, state.schema.text(text));
+            view.dispatch(tr);
+          })
+          .catch(err => {
+            console.warn('Failed to read clipboard for plain text paste:', err);
+          });
+
+        return true;
+      }
+    };
+  },
+
+  addProseMirrorPlugins() {
+    const options = this.options;
+
+    return [
+      new Plugin({
+        key: new PluginKey('pasteHandler'),
+        props: {
+          // Handle paste events
+          transformPastedHTML: (html: string) => {
+            // If formatting not allowed, strip all HTML tags
+            if (!options.allowPasteFormatting) {
+              const doc = new DOMParser().parseFromString(html, 'text/html');
+              return doc.body.textContent || '';
+            }
+
+            // Sanitize HTML to remove dangerous content
+            return sanitizeHTML(html, options.allowPasteImages);
+          },
+
+          // Handle pasted slices (for advanced sanitization)
+          transformPasted: (slice: Slice) => {
+            // If images not allowed, strip them from the slice
+            if (!options.allowPasteImages) {
+              return new Slice(stripImagesFromFragment(slice.content), slice.openStart, slice.openEnd);
+            }
+
+            return slice;
+          }
+        }
+      })
+    ];
+  }
+});
+
+/**
+ * Recursively strips image nodes from a ProseMirror fragment.
+ *
+ * @param fragment The fragment to process
+ * @returns A new fragment with images removed
+ */
+function stripImagesFromFragment(fragment: Fragment): Fragment {
+  const nodes: ProseMirrorNode[] = [];
+
+  fragment.forEach((node: ProseMirrorNode) => {
+    // Skip image nodes
+    if (node.type.name === 'image') {
+      return;
+    }
+
+    // Recursively process child nodes
+    if (node.content.size > 0) {
+      const newContent = stripImagesFromFragment(node.content);
+      nodes.push(node.copy(newContent));
+    } else {
+      nodes.push(node);
+    }
+  });
+
+  return Fragment.fromArray(nodes);
+}

--- a/packages/extended/src/lib/rich-text-editor/extensions/sanitize-utils.ts
+++ b/packages/extended/src/lib/rich-text-editor/extensions/sanitize-utils.ts
@@ -1,0 +1,152 @@
+/**
+ * Shared sanitization utilities for the rich text editor.
+ * Single source of truth for protocol blocklists, HTML sanitization, and JSON sanitization.
+ */
+
+export const DANGEROUS_PROTOCOLS = ['javascript:', 'data:', 'vbscript:', 'file:', 'about:', 'blob:'];
+
+/**
+ * Sanitizes HTML content by removing dangerous elements and attributes.
+ * Uses DOMParser for inert parsing to avoid eager resource fetches (e.g. img src beacons).
+ *
+ * @param html The HTML string to sanitize
+ * @param allowImages Whether to preserve img elements
+ * @returns Sanitized HTML string
+ */
+const MAX_HTML_SIZE = 1_000_000; // 1MB limit
+
+export function sanitizeHTML(html: string, allowImages = false): string {
+  if (html.length > MAX_HTML_SIZE) {
+    const sizeMB = (html.length / 1024 / 1024).toFixed(2);
+    console.warn(`[RTE Security] HTML content too large (${sizeMB}MB), truncating to 1MB`);
+    html = html.substring(0, MAX_HTML_SIZE);
+  }
+
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const temp = doc.body;
+
+  const dangerousSelectors = [
+    'script',
+    'iframe',
+    'embed',
+    'object',
+    'link',
+    'style',
+    'form',
+    'input',
+    'button',
+    'textarea',
+    'select',
+    'svg',
+    'math',
+    'audio',
+    'video',
+    'base'
+  ];
+
+  if (!allowImages) {
+    dangerousSelectors.push('img');
+  }
+
+  dangerousSelectors.forEach(selector => {
+    temp.querySelectorAll(selector).forEach(el => el.remove());
+  });
+
+  temp.querySelectorAll('*').forEach(el => {
+    Array.from(el.attributes).forEach(attr => {
+      if (attr.name.startsWith('on') || attr.name.startsWith('data-')) {
+        el.removeAttribute(attr.name);
+      }
+    });
+    el.removeAttribute('style');
+    el.removeAttribute('class');
+    el.removeAttribute('id');
+    el.removeAttribute('contenteditable');
+    el.removeAttribute('spellcheck');
+    el.removeAttribute('tabindex');
+  });
+
+  return temp.innerHTML;
+}
+
+/**
+ * Sanitizes a ProseMirror JSON object.
+ * - Deep-clones before mutating so the caller's object is never corrupted.
+ * - Validates structure depth and node count to prevent DoS.
+ * - Blocks dangerous protocols in link marks (raw and URL-encoded variants).
+ *
+ * @param json The ProseMirror JSON content to sanitize
+ * @returns The sanitized deep clone, or throws on DoS limit exceeded
+ */
+export function sanitizeJSON(json: unknown): unknown {
+  if (!json || typeof json !== 'object') {
+    return json;
+  }
+
+  const MAX_DEPTH = 50;
+  const MAX_NODES = 5000;
+  let nodeCount = 0;
+
+  const sanitize = (node: unknown, depth: number): unknown => {
+    if (depth > MAX_DEPTH) {
+      throw new Error('Maximum nesting depth exceeded (limit: 50)');
+    }
+
+    if (++nodeCount > MAX_NODES) {
+      throw new Error('Maximum node count exceeded (limit: 5000)');
+    }
+
+    if (!node || typeof node !== 'object') {
+      return node;
+    }
+
+    const n = node as Record<string, unknown>;
+
+    if (n.type === 'link' || (n.attrs && typeof n.attrs === 'object')) {
+      const attrs = n.attrs as Record<string, unknown>;
+      if (attrs.href && typeof attrs.href === 'string') {
+        const href = attrs.href.toLowerCase().trim();
+
+        for (const protocol of DANGEROUS_PROTOCOLS) {
+          if (href.startsWith(protocol)) {
+            console.warn('[RTE Security] Blocked dangerous protocol in link:', attrs.href);
+            attrs.href = '#';
+            break;
+          }
+        }
+
+        // Check URL-encoded variants (only if href wasn't already replaced)
+        if (attrs.href !== '#') {
+          try {
+            const decoded = decodeURIComponent(href);
+            for (const protocol of DANGEROUS_PROTOCOLS) {
+              if (decoded.includes(protocol)) {
+                console.warn('[RTE Security] Blocked encoded dangerous protocol:', attrs.href);
+                attrs.href = '#';
+                break;
+              }
+            }
+          } catch {
+            attrs.href = '#';
+          }
+        }
+      }
+    }
+
+    if (Array.isArray(n.content)) {
+      n.content = n.content.map(child => sanitize(child, depth + 1));
+    }
+    if (Array.isArray(n.marks)) {
+      n.marks = n.marks.map(mark => sanitize(mark, depth + 1));
+    }
+
+    return n;
+  };
+
+  try {
+    return sanitize(structuredClone(json), 0);
+  } catch (error) {
+    console.error('[RTE Security] Content sanitization failed:', error);
+    throw error;
+  }
+}


### PR DESCRIPTION
## Part 1 / 10 Rich Text Editor Verion 1.0 
PRs are split to provide easily digestible review of the Rich Text Editor

## What was added
Adds three standalone utility modules for the rich text editor:
- sanitize-utils: HTML/JSON sanitization with protocol blocklist
- paste-handler: TipTap paste extension with formatting/image controls
- markdown-serializer: ProseMirror-to-Markdown serialization

## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N (Test will be in a one of the follow up PRs in the series)
- Docs have been added/updated: Y (There is light JSDoc in this PR and Comments, these are mostly utility)
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
- sanitize-utils: Looks for dangerous protocols, selectors, and attributes and removes them. Also checks for max content size.
- paste handler: Sets up keyboard shortcut for pasting, makes use of the sanitize-utils for not allowing content over max count (plugin), image removal (based on config), sets up the paste plugin (handles paste content with sanitize-utils).
- markdown-serialization: takes JSONContent (tiptap interface)  and returns strings for each feature (heading, bold, ordered list)

## Additional information
This is the core foundation that the other PRs in this series will use heavily.
