### PR TITLE
feat(rich-text-editor): 6 of 10 - add standalone renderer component

### DIFF
--- a/packages/extended/src/dev/pages/rich-text-editor/rich-text-editor.ejs
+++ b/packages/extended/src/dev/pages/rich-text-editor/rich-text-editor.ejs
@@ -1,4 +1,9 @@
 <h2 class="forge-typography--heading4">Rich Text Editor</h2>
 <forge-rich-text-editor></forge-rich-text-editor>
 
+<h2 class="forge-typography--heading4">Renderer</h2>
+<forge-card outlined>
+  <forge-rich-text-renderer></forge-rich-text-renderer>
+</forge-card>
+
 <script type="module" src="rich-text-editor.ts"></script>

--- a/packages/extended/src/dev/pages/rich-text-editor/rich-text-editor.ejs
+++ b/packages/extended/src/dev/pages/rich-text-editor/rich-text-editor.ejs
@@ -1,9 +1,28 @@
-<h2 class="forge-typography--heading4">Rich Text Editor</h2>
-<forge-rich-text-editor></forge-rich-text-editor>
+<h2 class="forge-typography--heading4">Standalone</h2>
+<forge-rich-text-editor>
+  <forge-rte-standard-tools></forge-rte-standard-tools>
+  <forge-rte-feature-divider></forge-rte-feature-divider>
+  <forge-rte-code></forge-rte-code>
+  <forge-rte-link></forge-rte-link>
+</forge-rich-text-editor>
 
 <h2 class="forge-typography--heading4">Renderer</h2>
 <forge-card outlined>
   <forge-rich-text-renderer></forge-rich-text-renderer>
 </forge-card>
+
+<h2 class="forge-typography--heading4">Composed</h2>
+<forge-rich-text-context>
+  <forge-card class="toolbar" raised>
+    <div>
+      <forge-rte-standard-tools></forge-rte-standard-tools>
+    </div>
+  </forge-card>
+  <div class="content-container">
+    <forge-card class="content-card" raised>
+      <forge-rich-text-content></forge-rich-text-content>
+    </forge-card>
+  </div>
+</forge-rich-text-context>
 
 <script type="module" src="rich-text-editor.ts"></script>

--- a/packages/extended/src/dev/pages/rich-text-editor/rich-text-editor.ts
+++ b/packages/extended/src/dev/pages/rich-text-editor/rich-text-editor.ts
@@ -2,8 +2,21 @@ import '$dev/shared';
 import './rich-text-editor.scss';
 import '$lib/rich-text-editor';
 import { type RichTextEditorComponent } from '$lib/rich-text-editor';
+import { type RichTextRendererComponent } from '$lib/rich-text-editor/rich-text-renderer';
 
 const richTextEditor = document.querySelector('forge-rich-text-editor') as RichTextEditorComponent;
 richTextEditor.addEventListener('change', (evt: CustomEvent) => {
   console.log('Rich Text Editor Change Event:', evt.detail);
 });
+
+const richTextRenderer = document.querySelector('forge-rich-text-renderer') as RichTextRendererComponent;
+richTextRenderer.content = {
+  type: 'doc',
+  content: [
+    {
+      type: 'paragraph',
+      attrs: { textAlign: 'left' },
+      content: [{ type: 'text', text: 'Sample rendered content.' }]
+    }
+  ]
+} as unknown as RichTextRendererComponent['content'];

--- a/packages/extended/src/dev/pages/rich-text-editor/rich-text-editor.ts
+++ b/packages/extended/src/dev/pages/rich-text-editor/rich-text-editor.ts
@@ -1,6 +1,10 @@
 import '$dev/shared';
 import './rich-text-editor.scss';
 import '$lib/rich-text-editor';
+import '$lib/rich-text-editor/features/rte-standard-tools';
+import '$lib/rich-text-editor/features/rte-code';
+import '$lib/rich-text-editor/features/rte-link';
+import '$lib/rich-text-editor/rich-text-renderer';
 import { type RichTextEditorComponent } from '$lib/rich-text-editor';
 import { type RichTextRendererComponent } from '$lib/rich-text-editor/rich-text-renderer';
 
@@ -14,9 +18,74 @@ richTextRenderer.content = {
   type: 'doc',
   content: [
     {
+      type: 'heading',
+      attrs: { level: 1, textAlign: 'left' },
+      content: [{ type: 'text', text: 'Heading 1' }]
+    },
+    {
+      type: 'heading',
+      attrs: { level: 2, textAlign: 'left' },
+      content: [{ type: 'text', text: 'Heading 2' }]
+    },
+    {
+      type: 'heading',
+      attrs: { level: 3, textAlign: 'left' },
+      content: [{ type: 'text', text: 'Heading 3' }]
+    },
+    {
       type: 'paragraph',
       attrs: { textAlign: 'left' },
-      content: [{ type: 'text', text: 'Sample rendered content.' }]
+      content: [
+        { type: 'text', marks: [{ type: 'bold' }], text: 'Bold' },
+        { type: 'text', text: ', ' },
+        { type: 'text', marks: [{ type: 'italic' }], text: 'Italic' },
+        { type: 'text', text: ', ' },
+        { type: 'text', marks: [{ type: 'underline' }], text: 'Underline' },
+        { type: 'text', text: ', ' },
+        { type: 'text', marks: [{ type: 'strike' }], text: 'Strikethrough' },
+        { type: 'text', text: ', and ' },
+        { type: 'text', marks: [{ type: 'code' }], text: 'inline code' }
+      ]
+    },
+    {
+      type: 'paragraph',
+      attrs: { textAlign: 'left' },
+      content: [
+        { type: 'text', text: 'Visit the ' },
+        {
+          type: 'text',
+          marks: [{ type: 'link', attrs: { href: 'https://tylertech.com', target: '_blank', rel: 'noopener noreferrer nofollow' } }],
+          text: 'Tyler Technologies website'
+        },
+        { type: 'text', text: ' to learn more.' }
+      ]
+    },
+    {
+      type: 'paragraph',
+      attrs: { textAlign: 'center' },
+      content: [{ type: 'text', text: 'Center-aligned text' }]
+    },
+    {
+      type: 'paragraph',
+      attrs: { textAlign: 'right' },
+      content: [{ type: 'text', text: 'Right-aligned text' }]
+    },
+    {
+      type: 'bulletList',
+      content: [
+        { type: 'listItem', content: [{ type: 'paragraph', attrs: { textAlign: 'left' }, content: [{ type: 'text', text: 'Bullet item one' }] }] },
+        { type: 'listItem', content: [{ type: 'paragraph', attrs: { textAlign: 'left' }, content: [{ type: 'text', text: 'Bullet item two' }] }] },
+        { type: 'listItem', content: [{ type: 'paragraph', attrs: { textAlign: 'left' }, content: [{ type: 'text', text: 'Bullet item three' }] }] }
+      ]
+    },
+    {
+      type: 'orderedList',
+      attrs: { start: 1 },
+      content: [
+        { type: 'listItem', content: [{ type: 'paragraph', attrs: { textAlign: 'left' }, content: [{ type: 'text', text: 'Ordered item one' }] }] },
+        { type: 'listItem', content: [{ type: 'paragraph', attrs: { textAlign: 'left' }, content: [{ type: 'text', text: 'Ordered item two' }] }] },
+        { type: 'listItem', content: [{ type: 'paragraph', attrs: { textAlign: 'left' }, content: [{ type: 'text', text: 'Ordered item three' }] }] }
+      ]
     }
   ]
 } as unknown as RichTextRendererComponent['content'];

--- a/packages/extended/src/lib/rich-text-editor/index.ts
+++ b/packages/extended/src/lib/rich-text-editor/index.ts
@@ -1,9 +1,15 @@
 import { RichTextEditorComponent, RichTextEditorComponentTagName } from './rich-text-editor';
+import { RichTextRendererComponent, RichTextRendererComponentTagName } from './rich-text-renderer';
 import { tryDefine } from '@tylertech/forge-core';
 
 export * from './rich-text-editor';
+export * from './rich-text-renderer';
 export * from './editor-context';
 
 export function defineRichTextEditorComponent(): void {
   tryDefine(RichTextEditorComponentTagName, RichTextEditorComponent);
+}
+
+export function defineRichTextRendererComponent(): void {
+  tryDefine(RichTextRendererComponentTagName, RichTextRendererComponent);
 }

--- a/packages/extended/src/lib/rich-text-editor/rich-text-renderer.scss
+++ b/packages/extended/src/lib/rich-text-editor/rich-text-renderer.scss
@@ -1,0 +1,13 @@
+@use './core' as rte-core;
+
+@include rte-core.prosemirror-base();
+
+:host {
+  display: block;
+}
+
+.renderer-content {
+  padding: var(--forge-spacing-medium);
+
+  @include rte-core.content-styles();
+}

--- a/packages/extended/src/lib/rich-text-editor/rich-text-renderer.ts
+++ b/packages/extended/src/lib/rich-text-editor/rich-text-renderer.ts
@@ -1,0 +1,180 @@
+import { type AnyExtension, DocumentType, Editor as TipTapEditor, NodeType, TextType } from '@tiptap/core';
+import { Document } from '@tiptap/extension-document';
+import { Paragraph } from '@tiptap/extension-paragraph';
+import { Text } from '@tiptap/extension-text';
+import TextAlign from '@tiptap/extension-text-align';
+import Bold from '@tiptap/extension-bold';
+import Italic from '@tiptap/extension-italic';
+import Underline from '@tiptap/extension-underline';
+import Strike from '@tiptap/extension-strike';
+import Code from '@tiptap/extension-code';
+import { BulletList, ListItem, OrderedList } from '@tiptap/extension-list';
+import Link from '@tiptap/extension-link';
+import Heading from '@tiptap/extension-heading';
+import { html, LitElement, TemplateResult, unsafeCSS } from 'lit';
+import { customElement, property, query } from 'lit/decorators.js';
+
+import styles from './rich-text-renderer.scss?inline';
+import { sanitizeJSON } from './extensions/sanitize-utils';
+
+/**
+ * Type representing rich text content in TipTap's ProseMirror JSON format.
+ * This is a complex generic type from TipTap that represents the document structure.
+ * The `any` types here are TipTap's internal representation and cannot be avoided
+ * without importing the entire TipTap schema system.
+ *
+ * This format is produced by the editor's `toJSON()` method and can be consumed
+ * by this renderer component for read-only display.
+ */
+export type RichTextRendererContent = DocumentType<
+  // Document attributes (TipTap internal format - schema-dependent)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Record<string, any> | undefined,
+  // Node types array (TipTap internal format - extension-dependent)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  NodeType<string, undefined | Record<string, any>, any, (NodeType | TextType)[]>[]
+>;
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'forge-rich-text-renderer': RichTextRendererComponent;
+  }
+}
+
+export const RichTextRendererComponentTagName: keyof HTMLElementTagNameMap = 'forge-rich-text-renderer';
+
+// Default extensions for the renderer - matches all editor features
+const DEFAULT_EXTENSIONS: AnyExtension[] = [
+  Document,
+  Paragraph,
+  Text,
+  Bold,
+  Italic,
+  Underline,
+  Strike,
+  Code,
+  BulletList,
+  OrderedList,
+  ListItem,
+  Heading.configure({ levels: [1, 2, 3] }),
+  Link.configure({
+    openOnClick: true,
+    HTMLAttributes: {
+      target: '_blank',
+      rel: 'noopener noreferrer nofollow'
+    }
+  }),
+  TextAlign.configure({
+    types: ['heading', 'paragraph']
+  })
+];
+
+/**
+ * @tag forge-rich-text-renderer
+ *
+ * @summary
+ * Renders rich text content in a read-only format for display purposes.
+ *
+ * @description
+ * This component is responsible for rendering rich text content in a read-only mode. It accepts
+ * content in ProseMirror JSON format (the same format produced by the editor's change event) and
+ * displays it with proper formatting. Use this component to display rich text content that was
+ * created with the forge-rich-text-editor component.
+ *
+ * The renderer supports all formatting features available in the editor:
+ * - Text formatting (bold, italic, underline, strikethrough, code)
+ * - Headings (H1, H2, H3)
+ * - Lists (bulleted, numbered)
+ * - Text alignment (left, center, right, justify)
+ * - Links (clickable with security attributes)
+ *
+ * @property {RichTextRendererContent} content - The content to render in ProseMirror JSON format.
+ */
+@customElement(RichTextRendererComponentTagName)
+export class RichTextRendererComponent extends LitElement {
+  public static override styles = unsafeCSS(styles);
+
+  @property({ type: Object })
+  public content?: RichTextRendererContent;
+
+  @query('.renderer-content')
+  private _contentElement?: HTMLElement;
+
+  private _editor?: TipTapEditor;
+
+  public override connectedCallback(): void {
+    super.connectedCallback();
+    this._initializeEditor();
+  }
+
+  public override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this._destroyEditor();
+  }
+
+  public override willUpdate(changedProperties: Map<string | symbol, unknown>): void {
+    if (changedProperties.has('content') && this._editor) {
+      this._updateContent();
+    }
+  }
+
+  private _initializeEditor(): void {
+    // Wait for first render to get the content element
+    this.updateComplete.then(() => {
+      if (!this._contentElement) {
+        return;
+      }
+
+      try {
+        const initialContent = this.content ? this.#sanitizeContent(this.content) : undefined;
+        this._editor = new TipTapEditor({
+          element: this._contentElement,
+          extensions: DEFAULT_EXTENSIONS,
+          editable: false,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          content: initialContent as any
+        });
+      } catch (error) {
+        console.error('[RichTextRenderer] Failed to initialize editor:', error);
+      }
+    });
+  }
+
+  private _destroyEditor(): void {
+    if (this._editor) {
+      this._editor.destroy();
+      this._editor = undefined;
+    }
+  }
+
+  private _updateContent(): void {
+    if (!this._editor) {
+      return;
+    }
+
+    try {
+      if (this.content) {
+        const sanitized = this.#sanitizeContent(this.content);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        this._editor.commands.setContent(sanitized as any);
+      } else {
+        this._editor.commands.clearContent();
+      }
+    } catch (error) {
+      console.error('[RichTextRenderer] Failed to update content:', error);
+    }
+  }
+
+  #sanitizeContent(content: unknown): unknown {
+    try {
+      return sanitizeJSON(content);
+    } catch (error) {
+      console.error('[RichTextRenderer] Content sanitization failed:', error);
+      return { type: 'doc', content: [] };
+    }
+  }
+
+  public override render(): TemplateResult {
+    return html` <div class="renderer-content" role="article" aria-label="Rich text content"></div> `;
+  }
+}

--- a/packages/extended/src/lib/rich-text-editor/tests/rich-text-markdown.test.ts
+++ b/packages/extended/src/lib/rich-text-editor/tests/rich-text-markdown.test.ts
@@ -1,0 +1,844 @@
+import { expect, fixture, html as testHtml } from '@open-wc/testing';
+import { RichTextEditorComponent } from '../rich-text-editor';
+import type { RichTextContextComponent } from '../rich-text-context';
+import { MarkdownSerializer } from '../extensions/markdown-serializer';
+import type { JSONContent } from '@tiptap/core';
+
+import '../index';
+import '../features/rte-standard-tools';
+import '../features/rte-link';
+
+/**
+ * Test suite for Markdown output functionality in the rich text editor.
+ *
+ * Tests the toMarkdown() method and MarkdownSerializer class to ensure proper
+ * conversion from ProseMirror JSON to Markdown format.
+ */
+describe('Rich Text Editor - Markdown Output', () => {
+  async function waitForEditor(element: RichTextEditorComponent | RichTextContextComponent): Promise<void> {
+    await element.updateComplete;
+
+    const isEditorTag = element.tagName.toLowerCase() === 'forge-rich-text-editor';
+
+    const getContext = (): RichTextContextComponent | null => {
+      if (isEditorTag) {
+        return (element.shadowRoot?.querySelector('forge-rich-text-context') as RichTextContextComponent) ?? null;
+      }
+      return element as RichTextContextComponent;
+    };
+
+    // Fast-path: already initialized
+    if (getContext()?.isInitialized) {
+      return;
+    }
+
+    // Wait via event OR polling fallback (in case the event was already dispatched)
+    await new Promise<void>(resolve => {
+      let resolved = false;
+      const done = (): void => {
+        if (!resolved) {
+          resolved = true;
+          resolve();
+        }
+      };
+
+      // Event-based: listen for 'initialized' on element (composed event from context)
+      element.addEventListener('initialized', done, { once: true });
+
+      // Poll fallback: in case the event was already dispatched before our listener
+      const interval = setInterval(() => {
+        if (getContext()?.isInitialized) {
+          clearInterval(interval);
+          element.removeEventListener('initialized', done);
+          done();
+        }
+      }, 50);
+
+      // Safety timeout: 5 seconds
+      setTimeout(() => {
+        clearInterval(interval);
+        element.removeEventListener('initialized', done);
+        done(); // resolve anyway so the test fails on the assertion, not with a timeout error
+      }, 3000);
+    });
+  }
+
+  describe('MarkdownSerializer', () => {
+    describe('Basic Text and Paragraphs', () => {
+      it('should serialize empty content', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: []
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        expect(markdown).to.equal('');
+      });
+
+      it('should serialize plain text paragraph', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [{ type: 'text', text: 'Hello world' }]
+            }
+          ]
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        expect(markdown).to.equal('Hello world\n\n');
+      });
+
+      it('should serialize multiple paragraphs', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: [
+            { type: 'paragraph', content: [{ type: 'text', text: 'First paragraph' }] },
+            { type: 'paragraph', content: [{ type: 'text', text: 'Second paragraph' }] }
+          ]
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        expect(markdown).to.equal('First paragraph\n\nSecond paragraph\n\n');
+      });
+
+      it('should serialize empty paragraphs', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: [
+            { type: 'paragraph', content: [{ type: 'text', text: 'First' }] },
+            { type: 'paragraph', content: [] },
+            { type: 'paragraph', content: [{ type: 'text', text: 'Second' }] }
+          ]
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        expect(markdown).to.equal('First\n\n\nSecond\n\n');
+      });
+    });
+
+    describe('Text Formatting Marks', () => {
+      it('should serialize bold text', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [{ type: 'text', text: 'bold text', marks: [{ type: 'bold' }] }]
+            }
+          ]
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        expect(markdown).to.equal('**bold text**\n\n');
+      });
+
+      it('should serialize italic text', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [{ type: 'text', text: 'italic text', marks: [{ type: 'italic' }] }]
+            }
+          ]
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        expect(markdown).to.equal('*italic text*\n\n');
+      });
+
+      it('should serialize underline text as HTML', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [{ type: 'text', text: 'underline text', marks: [{ type: 'underline' }] }]
+            }
+          ]
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        expect(markdown).to.equal('<u>underline text</u>\n\n');
+      });
+
+      it('should serialize strikethrough text', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [{ type: 'text', text: 'strike text', marks: [{ type: 'strike' }] }]
+            }
+          ]
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        expect(markdown).to.equal('~~strike text~~\n\n');
+      });
+
+      it('should serialize inline code', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [{ type: 'text', text: 'const x = 5;', marks: [{ type: 'code' }] }]
+            }
+          ]
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        expect(markdown).to.equal('`const x = 5;`\n\n');
+      });
+
+      it('should serialize combined marks (bold + italic)', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                {
+                  type: 'text',
+                  text: 'bold italic',
+                  marks: [{ type: 'bold' }, { type: 'italic' }]
+                }
+              ]
+            }
+          ]
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        expect(markdown).to.equal('***bold italic***\n\n');
+      });
+
+      it('should serialize mixed formatting in same paragraph', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                { type: 'text', text: 'Normal ' },
+                { type: 'text', text: 'bold', marks: [{ type: 'bold' }] },
+                { type: 'text', text: ' and ' },
+                { type: 'text', text: 'italic', marks: [{ type: 'italic' }] },
+                { type: 'text', text: ' text.' }
+              ]
+            }
+          ]
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        expect(markdown).to.equal('Normal **bold** and *italic* text.\n\n');
+      });
+    });
+
+    describe('Links', () => {
+      it('should serialize link', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                {
+                  type: 'text',
+                  text: 'Click here',
+                  marks: [{ type: 'link', attrs: { href: 'https://example.com' } }]
+                }
+              ]
+            }
+          ]
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        expect(markdown).to.equal('[Click here](https://example.com)\n\n');
+      });
+
+      it('should serialize link with formatting', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                {
+                  type: 'text',
+                  text: 'bold link',
+                  marks: [{ type: 'bold' }, { type: 'link', attrs: { href: 'https://example.com' } }]
+                }
+              ]
+            }
+          ]
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        expect(markdown).to.equal('[**bold link**](https://example.com)\n\n');
+      });
+
+      it('should serialize multiple links in paragraph', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                { type: 'text', text: 'Visit ' },
+                { type: 'text', text: 'example', marks: [{ type: 'link', attrs: { href: 'https://example.com' } }] },
+                { type: 'text', text: ' or ' },
+                { type: 'text', text: 'google', marks: [{ type: 'link', attrs: { href: 'https://google.com' } }] }
+              ]
+            }
+          ]
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        expect(markdown).to.equal('Visit [example](https://example.com) or [google](https://google.com)\n\n');
+      });
+    });
+
+    describe('Headings', () => {
+      it('should serialize H1 heading', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: [
+            {
+              type: 'heading',
+              attrs: { level: 1 },
+              content: [{ type: 'text', text: 'Heading 1' }]
+            }
+          ]
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        expect(markdown).to.equal('# Heading 1\n\n');
+      });
+
+      it('should serialize H2 heading', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: [
+            {
+              type: 'heading',
+              attrs: { level: 2 },
+              content: [{ type: 'text', text: 'Heading 2' }]
+            }
+          ]
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        expect(markdown).to.equal('## Heading 2\n\n');
+      });
+
+      it('should serialize H3 heading', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: [
+            {
+              type: 'heading',
+              attrs: { level: 3 },
+              content: [{ type: 'text', text: 'Heading 3' }]
+            }
+          ]
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        expect(markdown).to.equal('### Heading 3\n\n');
+      });
+
+      it('should serialize heading with formatting', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: [
+            {
+              type: 'heading',
+              attrs: { level: 1 },
+              content: [
+                { type: 'text', text: 'Bold ', marks: [{ type: 'bold' }] },
+                { type: 'text', text: 'Heading' }
+              ]
+            }
+          ]
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        expect(markdown).to.equal('# **Bold** Heading\n\n');
+      });
+
+      it('should serialize document with mixed headings and paragraphs', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: [
+            { type: 'heading', attrs: { level: 1 }, content: [{ type: 'text', text: 'Title' }] },
+            { type: 'paragraph', content: [{ type: 'text', text: 'Intro paragraph' }] },
+            { type: 'heading', attrs: { level: 2 }, content: [{ type: 'text', text: 'Section' }] },
+            { type: 'paragraph', content: [{ type: 'text', text: 'Section content' }] }
+          ]
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        expect(markdown).to.equal('# Title\n\nIntro paragraph\n\n## Section\n\nSection content\n\n');
+      });
+    });
+
+    describe('Lists', () => {
+      it('should serialize bullet list', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: [
+            {
+              type: 'bulletList',
+              content: [
+                { type: 'listItem', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'First item' }] }] },
+                { type: 'listItem', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Second item' }] }] }
+              ]
+            }
+          ]
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        expect(markdown).to.equal('- First item\n- Second item\n\n');
+      });
+
+      it('should serialize ordered list', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: [
+            {
+              type: 'orderedList',
+              content: [
+                { type: 'listItem', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'First item' }] }] },
+                { type: 'listItem', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Second item' }] }] }
+              ]
+            }
+          ]
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        expect(markdown).to.equal('1. First item\n2. Second item\n\n');
+      });
+
+      it('should serialize list items with formatting', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: [
+            {
+              type: 'bulletList',
+              content: [
+                {
+                  type: 'listItem',
+                  content: [
+                    {
+                      type: 'paragraph',
+                      content: [{ type: 'text', text: 'bold item', marks: [{ type: 'bold' }] }]
+                    }
+                  ]
+                },
+                {
+                  type: 'listItem',
+                  content: [
+                    {
+                      type: 'paragraph',
+                      content: [{ type: 'text', text: 'italic item', marks: [{ type: 'italic' }] }]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        expect(markdown).to.equal('- **bold item**\n- *italic item*\n\n');
+      });
+
+      it('should serialize list with links', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: [
+            {
+              type: 'bulletList',
+              content: [
+                {
+                  type: 'listItem',
+                  content: [
+                    {
+                      type: 'paragraph',
+                      content: [
+                        { type: 'text', text: 'Visit ' },
+                        {
+                          type: 'text',
+                          text: 'example',
+                          marks: [{ type: 'link', attrs: { href: 'https://example.com' } }]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        expect(markdown).to.equal('- Visit [example](https://example.com)\n\n');
+      });
+    });
+
+    describe('Text Alignment', () => {
+      it('should serialize center-aligned paragraph with HTML comment', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              attrs: { textAlign: 'center' },
+              content: [{ type: 'text', text: 'Centered text' }]
+            }
+          ]
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        expect(markdown).to.equal('<!-- align:center -->\nCentered text\n\n');
+      });
+
+      it('should serialize right-aligned paragraph with HTML comment', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              attrs: { textAlign: 'right' },
+              content: [{ type: 'text', text: 'Right-aligned text' }]
+            }
+          ]
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        expect(markdown).to.equal('<!-- align:right -->\nRight-aligned text\n\n');
+      });
+
+      it('should serialize justify-aligned paragraph with HTML comment', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              attrs: { textAlign: 'justify' },
+              content: [{ type: 'text', text: 'Justified text' }]
+            }
+          ]
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        expect(markdown).to.equal('<!-- align:justify -->\nJustified text\n\n');
+      });
+
+      it('should not add alignment comment for left-aligned paragraph', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              attrs: { textAlign: 'left' },
+              content: [{ type: 'text', text: 'Left-aligned text' }]
+            }
+          ]
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        expect(markdown).to.equal('Left-aligned text\n\n');
+      });
+    });
+
+    describe('Complex Documents', () => {
+      it('should serialize document with all features', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: [
+            { type: 'heading', attrs: { level: 1 }, content: [{ type: 'text', text: 'Document Title' }] },
+            {
+              type: 'paragraph',
+              content: [
+                { type: 'text', text: 'This is ' },
+                { type: 'text', text: 'bold', marks: [{ type: 'bold' }] },
+                { type: 'text', text: ' and ' },
+                { type: 'text', text: 'italic', marks: [{ type: 'italic' }] },
+                { type: 'text', text: ' text.' }
+              ]
+            },
+            { type: 'heading', attrs: { level: 2 }, content: [{ type: 'text', text: 'Features' }] },
+            {
+              type: 'bulletList',
+              content: [
+                { type: 'listItem', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Bullet one' }] }] },
+                { type: 'listItem', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Bullet two' }] }] }
+              ]
+            },
+            {
+              type: 'paragraph',
+              content: [
+                { type: 'text', text: 'Visit ' },
+                { type: 'text', text: 'our site', marks: [{ type: 'link', attrs: { href: 'https://example.com' } }] }
+              ]
+            }
+          ]
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        expect(markdown).to.equal(
+          '# Document Title\n\n' +
+            'This is **bold** and *italic* text.\n\n' +
+            '## Features\n\n' +
+            '- Bullet one\n- Bullet two\n\n' +
+            'Visit [our site](https://example.com)\n\n'
+        );
+      });
+    });
+
+    describe('Edge Cases', () => {
+      it('should handle null/undefined content gracefully', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: undefined
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        expect(markdown).to.equal('');
+      });
+
+      it('should handle unknown node types gracefully', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: [{ type: 'unknownNode', content: [{ type: 'text', text: 'Should be skipped' }] }]
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        expect(markdown).to.equal('Should be skipped');
+      });
+
+      it('should handle empty lists', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: [{ type: 'bulletList', content: [] }]
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        expect(markdown).to.equal('\n');
+      });
+    });
+  });
+
+  describe('toMarkdown() Method', () => {
+    describe('RichTextEditorComponent', () => {
+      it('should return empty string when editor is not initialized', async () => {
+        const element = await fixture<RichTextEditorComponent>(testHtml`
+          <forge-rich-text-editor></forge-rich-text-editor>
+        `);
+
+        const markdown = element.toMarkdown();
+        expect(markdown).to.equal('');
+      });
+
+      it('should return markdown for plain text content', async () => {
+        const element = await fixture<RichTextEditorComponent>(testHtml`
+          <forge-rich-text-editor content="<p>Hello world</p>">
+            <forge-rte-standard-tools></forge-rte-standard-tools>
+          </forge-rich-text-editor>
+        `);
+
+        await waitForEditor(element);
+
+        const markdown = element.toMarkdown();
+        expect(markdown).to.equal('Hello world\n\n');
+      });
+
+      it('should return markdown for formatted content', async () => {
+        const element = await fixture<RichTextEditorComponent>(testHtml`
+          <forge-rich-text-editor content="<p><strong>Bold</strong> and <em>italic</em></p>">
+            <forge-rte-standard-tools></forge-rte-standard-tools>
+          </forge-rich-text-editor>
+        `);
+
+        await waitForEditor(element);
+
+        const markdown = element.toMarkdown();
+        expect(markdown).to.equal('**Bold** and *italic*\n\n');
+      });
+
+      it('should return markdown for headings', async () => {
+        const element = await fixture<RichTextEditorComponent>(testHtml`
+          <forge-rich-text-editor content="<h1>Heading 1</h1><h2>Heading 2</h2>">
+            <forge-rte-standard-tools></forge-rte-standard-tools>
+          </forge-rich-text-editor>
+        `);
+
+        await waitForEditor(element);
+
+        const markdown = element.toMarkdown();
+        expect(markdown).to.equal('# Heading 1\n\n## Heading 2\n\n');
+      });
+
+      it('should return markdown for lists', async () => {
+        const element = await fixture<RichTextEditorComponent>(testHtml`
+          <forge-rich-text-editor content="<ul><li>Item 1</li><li>Item 2</li></ul>">
+            <forge-rte-standard-tools></forge-rte-standard-tools>
+          </forge-rich-text-editor>
+        `);
+
+        await waitForEditor(element);
+
+        const markdown = element.toMarkdown();
+        expect(markdown).to.equal('- Item 1\n- Item 2\n\n');
+      });
+
+      it('should return markdown for links', async () => {
+        const element = await fixture<RichTextEditorComponent>(testHtml`
+          <forge-rich-text-editor content='<p><a href="https://example.com">Click here</a></p>'>
+            <forge-rte-standard-tools></forge-rte-standard-tools>
+            <forge-rte-link></forge-rte-link>
+          </forge-rich-text-editor>
+        `);
+
+        await waitForEditor(element);
+
+        const markdown = element.toMarkdown();
+        expect(markdown).to.equal('[Click here](https://example.com)\n\n');
+      });
+
+      it('should return markdown for complex content', async () => {
+        const content = `
+          <h1>Title</h1>
+          <p>This is <strong>bold</strong> and <em>italic</em> text.</p>
+          <ul>
+            <li>First item</li>
+            <li>Second item</li>
+          </ul>
+          <p>Visit <a href="https://example.com">example</a></p>
+        `;
+
+        const element = await fixture<RichTextEditorComponent>(testHtml`
+          <forge-rich-text-editor .content=${content}>
+            <forge-rte-standard-tools></forge-rte-standard-tools>
+            <forge-rte-link></forge-rte-link>
+          </forge-rich-text-editor>
+        `);
+
+        await waitForEditor(element);
+
+        const markdown = element.toMarkdown();
+        expect(markdown).to.include('# Title');
+        expect(markdown).to.include('**bold**');
+        expect(markdown).to.include('*italic*');
+        expect(markdown).to.include('- First item');
+        expect(markdown).to.include('[example](https://example.com)');
+      });
+    });
+
+    describe('escape() is called; body text and hrefs escaped', () => {
+      it('should escape Markdown special characters in body text', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [{ type: 'text', text: 'text with *asterisks* and _underscores_' }]
+            }
+          ]
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        expect(markdown).to.include('\\*asterisks\\*');
+        expect(markdown).to.include('\\_underscores\\_');
+      });
+
+      it('should escape ] and ) in link text to prevent injection', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                {
+                  type: 'text',
+                  text: 'click]here)',
+                  marks: [{ type: 'link', attrs: { href: 'https://example.com' } }]
+                }
+              ]
+            }
+          ]
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        // Must not produce [click]here)](https://example.com) — that breaks out of the link
+        expect(markdown).to.include('\\]');
+        expect(markdown).to.include('\\)');
+      });
+
+      it('should percent-encode parens in link href to prevent injection', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                {
+                  type: 'text',
+                  text: 'link',
+                  marks: [{ type: 'link', attrs: { href: 'https://example.com/path(1)' } }]
+                }
+              ]
+            }
+          ]
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        // Parens in href must be encoded so the link doesn't break
+        expect(markdown).to.include('https://example.com/path%281%29');
+        expect(markdown).to.not.include('(1)');
+      });
+
+      it('should not double-escape code spans', () => {
+        const json: JSONContent = {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                {
+                  type: 'text',
+                  text: 'some *code*',
+                  marks: [{ type: 'code' }]
+                }
+              ]
+            }
+          ]
+        };
+
+        const markdown = MarkdownSerializer.serialize(json);
+        // Inside a code span, asterisks should be literal
+        expect(markdown).to.include('`some *code*`');
+      });
+    });
+
+    describe('RichTextContextComponent', () => {
+      it('should return markdown from context component', async () => {
+        const element = await fixture<RichTextContextComponent>(testHtml`
+          <forge-rich-text-context content="<p><strong>Bold text</strong></p>">
+            <forge-rte-standard-tools></forge-rte-standard-tools>
+            <forge-rich-text-content></forge-rich-text-content>
+          </forge-rich-text-context>
+        `);
+
+        await waitForEditor(element);
+
+        const markdown = element.toMarkdown();
+        expect(markdown).to.equal('**Bold text**\n\n');
+      });
+    });
+  });
+});

--- a/packages/extended/src/lib/rich-text-editor/tests/rich-text-output.test.ts
+++ b/packages/extended/src/lib/rich-text-editor/tests/rich-text-output.test.ts
@@ -1,0 +1,680 @@
+import { expect, fixture, html } from '@open-wc/testing';
+import type { RichTextEditorComponent } from '../rich-text-editor';
+import type { RichTextContextComponent } from '../rich-text-context';
+import type { Editor } from '@tiptap/core';
+import '../rich-text-editor';
+import '../features/rte-bold';
+import '../features/rte-italic';
+import '../features/rte-underline';
+import '../features/rte-heading';
+import '../features/rte-bullet-list';
+import '../features/rte-ordered-list';
+import '../features/rte-link';
+
+async function getEditorContext(el: RichTextEditorComponent): Promise<RichTextContextComponent> {
+  await el.updateComplete;
+  const contextElement = el.shadowRoot?.querySelector('forge-rich-text-context') as RichTextContextComponent;
+  await contextElement?.updateComplete;
+  return contextElement;
+}
+
+async function getEditor(el: RichTextEditorComponent): Promise<Editor | null> {
+  const context = await getEditorContext(el);
+  await new Promise(resolve => setTimeout(resolve, 100));
+  return context.editorContext.editor;
+}
+
+describe('RTE Output Formats', () => {
+  it('should contain shadow root', async () => {
+    const el = await fixture<RichTextEditorComponent>(html`
+      <forge-rich-text-editor>
+        <forge-rte-bold></forge-rte-bold>
+      </forge-rich-text-editor>
+    `);
+
+    expect(el.shadowRoot).not.to.be.null;
+  });
+
+  describe('JSON Output', () => {
+    it('should return JSON for empty content', async () => {
+      const el = await fixture<RichTextEditorComponent>(html`
+        <forge-rich-text-editor>
+          <forge-rte-bold></forge-rte-bold>
+        </forge-rich-text-editor>
+      `);
+
+      const context = await getEditorContext(el);
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const json = context.toJSON();
+      expect(json).to.be.an('object');
+      expect(json).to.have.property('type', 'doc');
+      expect(json).to.have.property('content');
+    });
+
+    it('should return JSON for plain text content', async () => {
+      const el = await fixture<RichTextEditorComponent>(html`
+        <forge-rich-text-editor>
+          <forge-rte-bold></forge-rte-bold>
+        </forge-rich-text-editor>
+      `);
+
+      const editor = await getEditor(el);
+      const context = await getEditorContext(el);
+
+      editor?.commands.setContent('<p>Hello World</p>');
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const json = context.toJSON();
+      expect(json).to.be.an('object');
+      expect(json).to.have.property('type', 'doc');
+
+      const content = json?.content as unknown[];
+      expect(content).to.be.an('array');
+      expect(content[0]).to.have.property('type', 'paragraph');
+      expect(content[0].content[0]).to.have.property('text', 'Hello World');
+    });
+
+    it('should return JSON for bold text', async () => {
+      const el = await fixture<RichTextEditorComponent>(html`
+        <forge-rich-text-editor>
+          <forge-rte-bold></forge-rte-bold>
+        </forge-rich-text-editor>
+      `);
+
+      const editor = await getEditor(el);
+      const context = await getEditorContext(el);
+
+      editor?.commands.setContent('<p><strong>Bold Text</strong></p>');
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const json = context.toJSON();
+      const content = json?.content as unknown[];
+      const textNode = content[0].content[0];
+
+      expect(textNode).to.have.property('text', 'Bold Text');
+      expect(textNode.marks).to.be.an('array');
+      expect(textNode.marks[0]).to.have.property('type', 'bold');
+    });
+
+    it('should return JSON for multiple formatting marks', async () => {
+      const el = await fixture<RichTextEditorComponent>(html`
+        <forge-rich-text-editor>
+          <forge-rte-bold></forge-rte-bold>
+          <forge-rte-italic></forge-rte-italic>
+          <forge-rte-underline></forge-rte-underline>
+        </forge-rich-text-editor>
+      `);
+
+      const editor = await getEditor(el);
+      const context = await getEditorContext(el);
+
+      editor?.commands.setContent('<p><strong><em><u>Formatted</u></em></strong></p>');
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const json = context.toJSON();
+      const content = json?.content as unknown[];
+      const textNode = content[0].content[0];
+
+      expect(textNode).to.have.property('text', 'Formatted');
+      expect(textNode.marks).to.be.an('array');
+      expect(textNode.marks).to.have.lengthOf(3);
+    });
+
+    it('should return JSON for headings', async () => {
+      const el = await fixture<RichTextEditorComponent>(html`
+        <forge-rich-text-editor>
+          <forge-rte-heading></forge-rte-heading>
+        </forge-rich-text-editor>
+      `);
+
+      const editor = await getEditor(el);
+      const context = await getEditorContext(el);
+
+      editor?.commands.setContent('<h1>Heading 1</h1><h2>Heading 2</h2>');
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const json = context.toJSON();
+      const content = json?.content as unknown[];
+
+      expect(content[0]).to.have.property('type', 'heading');
+      expect(content[0].attrs).to.have.property('level', 1);
+      expect(content[0].content[0]).to.have.property('text', 'Heading 1');
+
+      expect(content[1]).to.have.property('type', 'heading');
+      expect(content[1].attrs).to.have.property('level', 2);
+      expect(content[1].content[0]).to.have.property('text', 'Heading 2');
+    });
+
+    it('should return JSON for bullet lists', async () => {
+      const el = await fixture<RichTextEditorComponent>(html`
+        <forge-rich-text-editor>
+          <forge-rte-bullet-list></forge-rte-bullet-list>
+        </forge-rich-text-editor>
+      `);
+
+      const editor = await getEditor(el);
+      const context = await getEditorContext(el);
+
+      editor?.commands.setContent('<ul><li><p>Item 1</p></li><li><p>Item 2</p></li></ul>');
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const json = context.toJSON();
+      const content = json?.content as unknown[];
+
+      expect(content[0]).to.have.property('type', 'bulletList');
+      expect(content[0].content).to.be.an('array');
+      expect(content[0].content).to.have.lengthOf(2);
+      expect(content[0].content[0]).to.have.property('type', 'listItem');
+    });
+
+    it('should return JSON for ordered lists', async () => {
+      const el = await fixture<RichTextEditorComponent>(html`
+        <forge-rich-text-editor>
+          <forge-rte-ordered-list></forge-rte-ordered-list>
+        </forge-rich-text-editor>
+      `);
+
+      const editor = await getEditor(el);
+      const context = await getEditorContext(el);
+
+      editor?.commands.setContent('<ol><li><p>First</p></li><li><p>Second</p></li></ol>');
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const json = context.toJSON();
+      const content = json?.content as unknown[];
+
+      expect(content[0]).to.have.property('type', 'orderedList');
+      expect(content[0].content).to.be.an('array');
+      expect(content[0].content).to.have.lengthOf(2);
+    });
+
+    it('should return JSON for links', async () => {
+      const el = await fixture<RichTextEditorComponent>(html`
+        <forge-rich-text-editor>
+          <forge-rte-link></forge-rte-link>
+        </forge-rich-text-editor>
+      `);
+
+      const editor = await getEditor(el);
+      const context = await getEditorContext(el);
+
+      editor?.commands.setContent('<p><a href="https://example.com">Link Text</a></p>');
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const json = context.toJSON();
+      const content = json?.content as unknown[];
+      const textNode = content[0].content[0];
+
+      expect(textNode).to.have.property('text', 'Link Text');
+      expect(textNode.marks).to.be.an('array');
+      expect(textNode.marks[0]).to.have.property('type', 'link');
+      expect(textNode.marks[0].attrs).to.have.property('href', 'https://example.com');
+    });
+
+    it('should return undefined when editor is not initialized', async () => {
+      const el = await fixture<RichTextEditorComponent>(html`
+        <forge-rich-text-editor>
+          <forge-rte-bold></forge-rte-bold>
+        </forge-rich-text-editor>
+      `);
+
+      const context = await getEditorContext(el);
+
+      // Force destroy the editor
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (context as any)._editor?.destroy();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (context as any)._editor = undefined;
+
+      const json = context.toJSON();
+      expect(json).to.be.undefined;
+    });
+
+    it('should preserve complex nested structures in JSON', async () => {
+      const el = await fixture<RichTextEditorComponent>(html`
+        <forge-rich-text-editor>
+          <forge-rte-heading></forge-rte-heading>
+          <forge-rte-bold></forge-rte-bold>
+          <forge-rte-italic></forge-rte-italic>
+          <forge-rte-bullet-list></forge-rte-bullet-list>
+        </forge-rich-text-editor>
+      `);
+
+      const editor = await getEditor(el);
+      const context = await getEditorContext(el);
+
+      editor?.commands.setContent(
+        '<h1>Title</h1><p>Paragraph with <strong>bold</strong> and <em>italic</em></p><ul><li><p>List item</p></li></ul>'
+      );
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const json = context.toJSON();
+      const content = json?.content as unknown[];
+
+      expect(content).to.have.lengthOf(3);
+      expect(content[0]).to.have.property('type', 'heading');
+      expect(content[1]).to.have.property('type', 'paragraph');
+      expect(content[2]).to.have.property('type', 'bulletList');
+    });
+  });
+
+  describe('HTML Output', () => {
+    it('should return HTML for empty content', async () => {
+      const el = await fixture<RichTextEditorComponent>(html`
+        <forge-rich-text-editor>
+          <forge-rte-bold></forge-rte-bold>
+        </forge-rich-text-editor>
+      `);
+
+      const context = await getEditorContext(el);
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const htmlOutput = context.toHTML();
+      expect(htmlOutput).to.be.a('string');
+      // Empty editor has a paragraph tag
+      expect(htmlOutput).to.include('<p>');
+    });
+
+    it('should return HTML for plain text content', async () => {
+      const el = await fixture<RichTextEditorComponent>(html`
+        <forge-rich-text-editor>
+          <forge-rte-bold></forge-rte-bold>
+        </forge-rich-text-editor>
+      `);
+
+      const editor = await getEditor(el);
+      const context = await getEditorContext(el);
+
+      editor?.commands.setContent('<p>Hello World</p>');
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const htmlOutput = context.toHTML();
+      expect(htmlOutput).to.equal('<p>Hello World</p>');
+    });
+
+    it('should return HTML for bold text', async () => {
+      const el = await fixture<RichTextEditorComponent>(html`
+        <forge-rich-text-editor>
+          <forge-rte-bold></forge-rte-bold>
+        </forge-rich-text-editor>
+      `);
+
+      const editor = await getEditor(el);
+      const context = await getEditorContext(el);
+
+      editor?.commands.setContent('<p><strong>Bold Text</strong></p>');
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const htmlOutput = context.toHTML();
+      expect(htmlOutput).to.equal('<p><strong>Bold Text</strong></p>');
+    });
+
+    it('should return HTML for multiple formatting marks', async () => {
+      const el = await fixture<RichTextEditorComponent>(html`
+        <forge-rich-text-editor>
+          <forge-rte-bold></forge-rte-bold>
+          <forge-rte-italic></forge-rte-italic>
+          <forge-rte-underline></forge-rte-underline>
+        </forge-rich-text-editor>
+      `);
+
+      const editor = await getEditor(el);
+      const context = await getEditorContext(el);
+
+      editor?.commands.setContent('<p><strong><em><u>Formatted</u></em></strong></p>');
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const htmlOutput = context.toHTML();
+      expect(htmlOutput).to.include('Formatted');
+      expect(htmlOutput).to.include('<strong>');
+      expect(htmlOutput).to.include('<em>');
+      expect(htmlOutput).to.include('<u>');
+    });
+
+    it('should return HTML for headings', async () => {
+      const el = await fixture<RichTextEditorComponent>(html`
+        <forge-rich-text-editor>
+          <forge-rte-heading></forge-rte-heading>
+        </forge-rich-text-editor>
+      `);
+
+      const editor = await getEditor(el);
+      const context = await getEditorContext(el);
+
+      editor?.commands.setContent('<h1>Heading 1</h1><h2>Heading 2</h2><h3>Heading 3</h3>');
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const htmlOutput = context.toHTML();
+      expect(htmlOutput).to.include('<h1>Heading 1</h1>');
+      expect(htmlOutput).to.include('<h2>Heading 2</h2>');
+      expect(htmlOutput).to.include('<h3>Heading 3</h3>');
+    });
+
+    it('should return HTML for bullet lists', async () => {
+      const el = await fixture<RichTextEditorComponent>(html`
+        <forge-rich-text-editor>
+          <forge-rte-bullet-list></forge-rte-bullet-list>
+        </forge-rich-text-editor>
+      `);
+
+      const editor = await getEditor(el);
+      const context = await getEditorContext(el);
+
+      editor?.commands.setContent('<ul><li><p>Item 1</p></li><li><p>Item 2</p></li></ul>');
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const htmlOutput = context.toHTML();
+      expect(htmlOutput).to.include('<ul>');
+      expect(htmlOutput).to.include('<li>');
+      expect(htmlOutput).to.include('Item 1');
+      expect(htmlOutput).to.include('Item 2');
+      expect(htmlOutput).to.include('</ul>');
+    });
+
+    it('should return HTML for ordered lists', async () => {
+      const el = await fixture<RichTextEditorComponent>(html`
+        <forge-rich-text-editor>
+          <forge-rte-ordered-list></forge-rte-ordered-list>
+        </forge-rich-text-editor>
+      `);
+
+      const editor = await getEditor(el);
+      const context = await getEditorContext(el);
+
+      editor?.commands.setContent('<ol><li><p>First</p></li><li><p>Second</p></li></ol>');
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const htmlOutput = context.toHTML();
+      expect(htmlOutput).to.include('<ol>');
+      expect(htmlOutput).to.include('<li>');
+      expect(htmlOutput).to.include('First');
+      expect(htmlOutput).to.include('Second');
+      expect(htmlOutput).to.include('</ol>');
+    });
+
+    it('should return HTML for links', async () => {
+      const el = await fixture<RichTextEditorComponent>(html`
+        <forge-rich-text-editor>
+          <forge-rte-link></forge-rte-link>
+        </forge-rich-text-editor>
+      `);
+
+      const editor = await getEditor(el);
+      const context = await getEditorContext(el);
+
+      editor?.commands.setContent('<p><a href="https://example.com">Link Text</a></p>');
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const htmlOutput = context.toHTML();
+      expect(htmlOutput).to.include('<a');
+      expect(htmlOutput).to.include('href="https://example.com"');
+      expect(htmlOutput).to.include('Link Text');
+      expect(htmlOutput).to.include('</a>');
+    });
+
+    it('should return empty string when editor is not initialized', async () => {
+      const el = await fixture<RichTextEditorComponent>(html`
+        <forge-rich-text-editor>
+          <forge-rte-bold></forge-rte-bold>
+        </forge-rich-text-editor>
+      `);
+
+      const context = await getEditorContext(el);
+
+      // Force destroy the editor
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (context as any)._editor?.destroy();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (context as any)._editor = undefined;
+
+      const htmlOutput = context.toHTML();
+      expect(htmlOutput).to.equal('');
+    });
+
+    it('should preserve complex nested structures in HTML', async () => {
+      const el = await fixture<RichTextEditorComponent>(html`
+        <forge-rich-text-editor>
+          <forge-rte-heading></forge-rte-heading>
+          <forge-rte-bold></forge-rte-bold>
+          <forge-rte-italic></forge-rte-italic>
+          <forge-rte-bullet-list></forge-rte-bullet-list>
+        </forge-rich-text-editor>
+      `);
+
+      const editor = await getEditor(el);
+      const context = await getEditorContext(el);
+
+      editor?.commands.setContent(
+        '<h1>Title</h1><p>Paragraph with <strong>bold</strong> and <em>italic</em></p><ul><li><p>List item</p></li></ul>'
+      );
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const htmlOutput = context.toHTML();
+      expect(htmlOutput).to.include('<h1>Title</h1>');
+      expect(htmlOutput).to.include('<p>Paragraph with <strong>bold</strong> and <em>italic</em></p>');
+      expect(htmlOutput).to.include('<ul>');
+      expect(htmlOutput).to.include('<li>');
+    });
+
+    it('should handle special characters in HTML output', async () => {
+      const el = await fixture<RichTextEditorComponent>(html`
+        <forge-rich-text-editor>
+          <forge-rte-bold></forge-rte-bold>
+        </forge-rich-text-editor>
+      `);
+
+      const editor = await getEditor(el);
+      const context = await getEditorContext(el);
+
+      editor?.commands.setContent('<p>&lt;tag&gt; &amp; special chars</p>');
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const htmlOutput = context.toHTML();
+      // TipTap correctly preserves HTML entities for security
+      expect(htmlOutput).to.include('&lt;tag&gt;');
+      expect(htmlOutput).to.include('&amp;');
+      expect(htmlOutput).to.include('special chars');
+    });
+  });
+
+  describe('Content Roundtrip', () => {
+    it('should preserve content through HTML -> Editor -> HTML', async () => {
+      const originalHTML = '<p>Test paragraph with <strong>bold</strong> text</p>';
+
+      const el = await fixture<RichTextEditorComponent>(html`
+        <forge-rich-text-editor>
+          <forge-rte-bold></forge-rte-bold>
+        </forge-rich-text-editor>
+      `);
+
+      const editor = await getEditor(el);
+      const context = await getEditorContext(el);
+
+      editor?.commands.setContent(originalHTML);
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const outputHTML = context.toHTML();
+      expect(outputHTML).to.equal(originalHTML);
+    });
+
+    it('should preserve content through HTML -> JSON -> HTML', async () => {
+      const originalHTML = '<p>Test with <em>italic</em></p>';
+
+      const el = await fixture<RichTextEditorComponent>(html`
+        <forge-rich-text-editor>
+          <forge-rte-italic></forge-rte-italic>
+        </forge-rich-text-editor>
+      `);
+
+      const editor = await getEditor(el);
+      const context = await getEditorContext(el);
+
+      editor?.commands.setContent(originalHTML);
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      // Get JSON representation
+      const json = context.toJSON();
+      expect(json).to.be.an('object');
+
+      // Verify HTML output matches
+      const outputHTML = context.toHTML();
+      expect(outputHTML).to.equal(originalHTML);
+    });
+
+    it('should preserve list structure through roundtrip', async () => {
+      const originalHTML = '<ul><li><p>Item 1</p></li><li><p>Item 2</p></li></ul>';
+
+      const el = await fixture<RichTextEditorComponent>(html`
+        <forge-rich-text-editor>
+          <forge-rte-bullet-list></forge-rte-bullet-list>
+        </forge-rich-text-editor>
+      `);
+
+      const editor = await getEditor(el);
+      const context = await getEditorContext(el);
+
+      editor?.commands.setContent(originalHTML);
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const outputHTML = context.toHTML();
+      expect(outputHTML).to.equal(originalHTML);
+    });
+
+    it('should preserve headings through roundtrip', async () => {
+      const originalHTML = '<h1>Title</h1><p>Content</p>';
+
+      const el = await fixture<RichTextEditorComponent>(html`
+        <forge-rich-text-editor>
+          <forge-rte-heading></forge-rte-heading>
+        </forge-rich-text-editor>
+      `);
+
+      const editor = await getEditor(el);
+      const context = await getEditorContext(el);
+
+      editor?.commands.setContent(originalHTML);
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const outputHTML = context.toHTML();
+      expect(outputHTML).to.equal(originalHTML);
+    });
+  });
+
+  describe('Editor Component Methods', () => {
+    it('should expose toJSON method on main editor component', async () => {
+      const el = await fixture<RichTextEditorComponent>(html`
+        <forge-rich-text-editor>
+          <forge-rte-bold></forge-rte-bold>
+        </forge-rich-text-editor>
+      `);
+
+      const editor = await getEditor(el);
+      editor?.commands.setContent('<p>Test</p>');
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      expect(el).to.have.property('toJSON');
+      expect(typeof el.toJSON).to.equal('function');
+
+      const json = el.toJSON();
+      expect(json).to.be.an('object');
+    });
+
+    it('should expose toHTML method on main editor component', async () => {
+      const el = await fixture<RichTextEditorComponent>(html`
+        <forge-rich-text-editor>
+          <forge-rte-bold></forge-rte-bold>
+        </forge-rich-text-editor>
+      `);
+
+      const editor = await getEditor(el);
+      editor?.commands.setContent('<p>Test</p>');
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      expect(el).to.have.property('toHTML');
+      expect(typeof el.toHTML).to.equal('function');
+
+      const htmlResult = el.toHTML();
+      expect(htmlResult).to.be.a('string');
+      expect(htmlResult).to.equal('<p>Test</p>');
+    });
+
+    it('should return correct JSON from main editor component', async () => {
+      const el = await fixture<RichTextEditorComponent>(html`
+        <forge-rich-text-editor>
+          <forge-rte-bold></forge-rte-bold>
+        </forge-rich-text-editor>
+      `);
+
+      const editor = await getEditor(el);
+      editor?.commands.setContent('<p><strong>Bold</strong></p>');
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const json = el.toJSON();
+      const content = json?.content as unknown[];
+
+      expect(content[0].content[0]).to.have.property('text', 'Bold');
+      expect(content[0].content[0].marks[0]).to.have.property('type', 'bold');
+    });
+
+    it('should return correct HTML from main editor component', async () => {
+      const el = await fixture<RichTextEditorComponent>(html`
+        <forge-rich-text-editor>
+          <forge-rte-bold></forge-rte-bold>
+        </forge-rich-text-editor>
+      `);
+
+      const editor = await getEditor(el);
+      editor?.commands.setContent('<p><strong>Bold</strong></p>');
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const htmlResult = el.toHTML();
+      expect(htmlResult).to.equal('<p><strong>Bold</strong></p>');
+    });
+  });
+
+  describe('Dynamic Content Updates', () => {
+    it('should return updated JSON after content change', async () => {
+      const el = await fixture<RichTextEditorComponent>(html`
+        <forge-rich-text-editor>
+          <forge-rte-bold></forge-rte-bold>
+        </forge-rich-text-editor>
+      `);
+
+      const editor = await getEditor(el);
+      const context = await getEditorContext(el);
+
+      editor?.commands.setContent('<p>Initial</p>');
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      // Update content
+      editor?.commands.setContent('<p>Updated</p>');
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const json = context.toJSON();
+      const content = json?.content as unknown[];
+      expect(content[0].content[0]).to.have.property('text', 'Updated');
+    });
+
+    it('should return updated HTML after content change', async () => {
+      const el = await fixture<RichTextEditorComponent>(html`
+        <forge-rich-text-editor>
+          <forge-rte-bold></forge-rte-bold>
+        </forge-rich-text-editor>
+      `);
+
+      const editor = await getEditor(el);
+      const context = await getEditorContext(el);
+
+      editor?.commands.setContent('<p>Initial</p>');
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      // Update content
+      editor?.commands.setContent('<p>Updated</p>');
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const htmlResult = context.toHTML();
+      expect(htmlResult).to.equal('<p>Updated</p>');
+    });
+  });
+});

--- a/packages/extended/src/lib/rich-text-editor/tests/rich-text-renderer.test.ts
+++ b/packages/extended/src/lib/rich-text-editor/tests/rich-text-renderer.test.ts
@@ -1,0 +1,824 @@
+import { expect, fixture, html } from '@open-wc/testing';
+import type { RichTextRendererComponent } from '../rich-text-renderer';
+import '../rich-text-renderer';
+
+describe('RichTextRendererComponent', () => {
+  describe('Component Structure', () => {
+    it('should contain shadow root', async () => {
+      const el = await fixture<RichTextRendererComponent>(html`<forge-rich-text-renderer></forge-rich-text-renderer>`);
+      expect(el.shadowRoot).not.to.be.null;
+    });
+
+    it('should render content container', async () => {
+      const el = await fixture<RichTextRendererComponent>(html`<forge-rich-text-renderer></forge-rich-text-renderer>`);
+      const container = el.shadowRoot?.querySelector('.renderer-content');
+      expect(container).to.exist;
+    });
+
+    it('should have proper ARIA role', async () => {
+      const el = await fixture<RichTextRendererComponent>(html`<forge-rich-text-renderer></forge-rich-text-renderer>`);
+      const container = el.shadowRoot?.querySelector('.renderer-content');
+      expect(container?.getAttribute('role')).to.equal('article');
+    });
+
+    it('should have proper ARIA label', async () => {
+      const el = await fixture<RichTextRendererComponent>(html`<forge-rich-text-renderer></forge-rich-text-renderer>`);
+      const container = el.shadowRoot?.querySelector('.renderer-content');
+      expect(container?.getAttribute('aria-label')).to.equal('Rich text content');
+    });
+  });
+
+  describe('Content Rendering', () => {
+    it('should render empty content', async () => {
+      const el = await fixture<RichTextRendererComponent>(html`<forge-rich-text-renderer></forge-rich-text-renderer>`);
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const container = el.shadowRoot?.querySelector('.renderer-content');
+      expect(container?.textContent?.trim()).to.equal('');
+    });
+
+    it('should render plain text paragraph', async () => {
+      const content = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: 'Hello world'
+              }
+            ]
+          }
+        ]
+      };
+
+      const el = await fixture<RichTextRendererComponent>(
+        html`<forge-rich-text-renderer .content=${content}></forge-rich-text-renderer>`
+      );
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const container = el.shadowRoot?.querySelector('.renderer-content');
+      expect(container?.textContent).to.include('Hello world');
+    });
+
+    it('should render multiple paragraphs', async () => {
+      const content = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'First paragraph' }]
+          },
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'Second paragraph' }]
+          }
+        ]
+      };
+
+      const el = await fixture<RichTextRendererComponent>(
+        html`<forge-rich-text-renderer .content=${content}></forge-rich-text-renderer>`
+      );
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const container = el.shadowRoot?.querySelector('.renderer-content');
+      const paragraphs = container?.querySelectorAll('p');
+      expect(paragraphs?.length).to.equal(2);
+      expect(paragraphs?.[0].textContent).to.equal('First paragraph');
+      expect(paragraphs?.[1].textContent).to.equal('Second paragraph');
+    });
+
+    it('should update content when property changes', async () => {
+      const content1 = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'Original content' }]
+          }
+        ]
+      };
+
+      const el = await fixture<RichTextRendererComponent>(
+        html`<forge-rich-text-renderer .content=${content1}></forge-rich-text-renderer>`
+      );
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const content2 = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'Updated content' }]
+          }
+        ]
+      };
+
+      el.content = content2;
+      await el.updateComplete;
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const container = el.shadowRoot?.querySelector('.renderer-content');
+      expect(container?.textContent).to.include('Updated content');
+      expect(container?.textContent).not.to.include('Original content');
+    });
+  });
+
+  describe('Text Formatting (Marks)', () => {
+    it('should render bold text', async () => {
+      const content = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: 'Bold text',
+                marks: [{ type: 'bold' }]
+              }
+            ]
+          }
+        ]
+      };
+
+      const el = await fixture<RichTextRendererComponent>(
+        html`<forge-rich-text-renderer .content=${content}></forge-rich-text-renderer>`
+      );
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const container = el.shadowRoot?.querySelector('.renderer-content');
+      const strong = container?.querySelector('strong');
+      expect(strong).to.exist;
+      expect(strong?.textContent).to.equal('Bold text');
+    });
+
+    it('should render italic text', async () => {
+      const content = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: 'Italic text',
+                marks: [{ type: 'italic' }]
+              }
+            ]
+          }
+        ]
+      };
+
+      const el = await fixture<RichTextRendererComponent>(
+        html`<forge-rich-text-renderer .content=${content}></forge-rich-text-renderer>`
+      );
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const container = el.shadowRoot?.querySelector('.renderer-content');
+      const em = container?.querySelector('em');
+      expect(em).to.exist;
+      expect(em?.textContent).to.equal('Italic text');
+    });
+
+    it('should render underlined text', async () => {
+      const content = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: 'Underlined text',
+                marks: [{ type: 'underline' }]
+              }
+            ]
+          }
+        ]
+      };
+
+      const el = await fixture<RichTextRendererComponent>(
+        html`<forge-rich-text-renderer .content=${content}></forge-rich-text-renderer>`
+      );
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const container = el.shadowRoot?.querySelector('.renderer-content');
+      const u = container?.querySelector('u');
+      expect(u).to.exist;
+      expect(u?.textContent).to.equal('Underlined text');
+    });
+
+    it('should render strikethrough text', async () => {
+      const content = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: 'Strikethrough text',
+                marks: [{ type: 'strike' }]
+              }
+            ]
+          }
+        ]
+      };
+
+      const el = await fixture<RichTextRendererComponent>(
+        html`<forge-rich-text-renderer .content=${content}></forge-rich-text-renderer>`
+      );
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const container = el.shadowRoot?.querySelector('.renderer-content');
+      const s = container?.querySelector('s');
+      expect(s).to.exist;
+      expect(s?.textContent).to.equal('Strikethrough text');
+    });
+
+    it('should render code text', async () => {
+      const content = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: 'const x = 42;',
+                marks: [{ type: 'code' }]
+              }
+            ]
+          }
+        ]
+      };
+
+      const el = await fixture<RichTextRendererComponent>(
+        html`<forge-rich-text-renderer .content=${content}></forge-rich-text-renderer>`
+      );
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const container = el.shadowRoot?.querySelector('.renderer-content');
+      const code = container?.querySelector('code');
+      expect(code).to.exist;
+      expect(code?.textContent).to.equal('const x = 42;');
+    });
+
+    it('should render combined formatting marks', async () => {
+      const content = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: 'Bold and italic',
+                marks: [{ type: 'bold' }, { type: 'italic' }]
+              }
+            ]
+          }
+        ]
+      };
+
+      const el = await fixture<RichTextRendererComponent>(
+        html`<forge-rich-text-renderer .content=${content}></forge-rich-text-renderer>`
+      );
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const container = el.shadowRoot?.querySelector('.renderer-content');
+      const strong = container?.querySelector('strong');
+      const em = container?.querySelector('em');
+      expect(strong).to.exist;
+      expect(em).to.exist;
+      expect(container?.textContent).to.include('Bold and italic');
+    });
+  });
+
+  describe('Headings', () => {
+    it('should render H1 heading', async () => {
+      const content = {
+        type: 'doc',
+        content: [
+          {
+            type: 'heading',
+            attrs: { level: 1 },
+            content: [{ type: 'text', text: 'Heading 1' }]
+          }
+        ]
+      };
+
+      const el = await fixture<RichTextRendererComponent>(
+        html`<forge-rich-text-renderer .content=${content}></forge-rich-text-renderer>`
+      );
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const container = el.shadowRoot?.querySelector('.renderer-content');
+      const h1 = container?.querySelector('h1');
+      expect(h1).to.exist;
+      expect(h1?.textContent).to.equal('Heading 1');
+    });
+
+    it('should render H2 heading', async () => {
+      const content = {
+        type: 'doc',
+        content: [
+          {
+            type: 'heading',
+            attrs: { level: 2 },
+            content: [{ type: 'text', text: 'Heading 2' }]
+          }
+        ]
+      };
+
+      const el = await fixture<RichTextRendererComponent>(
+        html`<forge-rich-text-renderer .content=${content}></forge-rich-text-renderer>`
+      );
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const container = el.shadowRoot?.querySelector('.renderer-content');
+      const h2 = container?.querySelector('h2');
+      expect(h2).to.exist;
+      expect(h2?.textContent).to.equal('Heading 2');
+    });
+
+    it('should render H3 heading', async () => {
+      const content = {
+        type: 'doc',
+        content: [
+          {
+            type: 'heading',
+            attrs: { level: 3 },
+            content: [{ type: 'text', text: 'Heading 3' }]
+          }
+        ]
+      };
+
+      const el = await fixture<RichTextRendererComponent>(
+        html`<forge-rich-text-renderer .content=${content}></forge-rich-text-renderer>`
+      );
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const container = el.shadowRoot?.querySelector('.renderer-content');
+      const h3 = container?.querySelector('h3');
+      expect(h3).to.exist;
+      expect(h3?.textContent).to.equal('Heading 3');
+    });
+
+    it('should render headings with formatting', async () => {
+      const content = {
+        type: 'doc',
+        content: [
+          {
+            type: 'heading',
+            attrs: { level: 2 },
+            content: [
+              {
+                type: 'text',
+                text: 'Bold Heading',
+                marks: [{ type: 'bold' }]
+              }
+            ]
+          }
+        ]
+      };
+
+      const el = await fixture<RichTextRendererComponent>(
+        html`<forge-rich-text-renderer .content=${content}></forge-rich-text-renderer>`
+      );
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const container = el.shadowRoot?.querySelector('.renderer-content');
+      const h2 = container?.querySelector('h2');
+      const strong = h2?.querySelector('strong');
+      expect(h2).to.exist;
+      expect(strong).to.exist;
+      expect(strong?.textContent).to.equal('Bold Heading');
+    });
+  });
+
+  describe('Lists', () => {
+    it('should render bullet list', async () => {
+      const content = {
+        type: 'doc',
+        content: [
+          {
+            type: 'bulletList',
+            content: [
+              {
+                type: 'listItem',
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [{ type: 'text', text: 'Item 1' }]
+                  }
+                ]
+              },
+              {
+                type: 'listItem',
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [{ type: 'text', text: 'Item 2' }]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      };
+
+      const el = await fixture<RichTextRendererComponent>(
+        html`<forge-rich-text-renderer .content=${content}></forge-rich-text-renderer>`
+      );
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const container = el.shadowRoot?.querySelector('.renderer-content');
+      const ul = container?.querySelector('ul');
+      const items = ul?.querySelectorAll('li');
+      expect(ul).to.exist;
+      expect(items?.length).to.equal(2);
+      expect(items?.[0].textContent).to.equal('Item 1');
+      expect(items?.[1].textContent).to.equal('Item 2');
+    });
+
+    it('should render ordered list', async () => {
+      const content = {
+        type: 'doc',
+        content: [
+          {
+            type: 'orderedList',
+            content: [
+              {
+                type: 'listItem',
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [{ type: 'text', text: 'First' }]
+                  }
+                ]
+              },
+              {
+                type: 'listItem',
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [{ type: 'text', text: 'Second' }]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      };
+
+      const el = await fixture<RichTextRendererComponent>(
+        html`<forge-rich-text-renderer .content=${content}></forge-rich-text-renderer>`
+      );
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const container = el.shadowRoot?.querySelector('.renderer-content');
+      const ol = container?.querySelector('ol');
+      const items = ol?.querySelectorAll('li');
+      expect(ol).to.exist;
+      expect(items?.length).to.equal(2);
+      expect(items?.[0].textContent).to.equal('First');
+      expect(items?.[1].textContent).to.equal('Second');
+    });
+
+    it('should render list items with formatting', async () => {
+      const content = {
+        type: 'doc',
+        content: [
+          {
+            type: 'bulletList',
+            content: [
+              {
+                type: 'listItem',
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [
+                      {
+                        type: 'text',
+                        text: 'Bold item',
+                        marks: [{ type: 'bold' }]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      };
+
+      const el = await fixture<RichTextRendererComponent>(
+        html`<forge-rich-text-renderer .content=${content}></forge-rich-text-renderer>`
+      );
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const container = el.shadowRoot?.querySelector('.renderer-content');
+      const strong = container?.querySelector('strong');
+      expect(strong).to.exist;
+      expect(strong?.textContent).to.equal('Bold item');
+    });
+  });
+
+  describe('Links', () => {
+    it('should render link', async () => {
+      const content = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: 'Click here',
+                marks: [
+                  {
+                    type: 'link',
+                    attrs: { href: 'https://example.com' }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      };
+
+      const el = await fixture<RichTextRendererComponent>(
+        html`<forge-rich-text-renderer .content=${content}></forge-rich-text-renderer>`
+      );
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const container = el.shadowRoot?.querySelector('.renderer-content');
+      const link = container?.querySelector('a');
+      expect(link).to.exist;
+      expect(link?.textContent).to.equal('Click here');
+      expect(link?.getAttribute('href')).to.equal('https://example.com');
+    });
+
+    it('should render link with security attributes', async () => {
+      const content = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: 'External link',
+                marks: [
+                  {
+                    type: 'link',
+                    attrs: { href: 'https://example.com' }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      };
+
+      const el = await fixture<RichTextRendererComponent>(
+        html`<forge-rich-text-renderer .content=${content}></forge-rich-text-renderer>`
+      );
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const container = el.shadowRoot?.querySelector('.renderer-content');
+      const link = container?.querySelector('a');
+      expect(link).to.exist;
+      expect(link?.getAttribute('target')).to.equal('_blank');
+      expect(link?.getAttribute('rel')).to.include('noopener');
+      expect(link?.getAttribute('rel')).to.include('noreferrer');
+      expect(link?.getAttribute('rel')).to.include('nofollow');
+    });
+
+    it('should render link with formatting', async () => {
+      const content = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: 'Bold link',
+                marks: [{ type: 'bold' }, { type: 'link', attrs: { href: 'https://example.com' } }]
+              }
+            ]
+          }
+        ]
+      };
+
+      const el = await fixture<RichTextRendererComponent>(
+        html`<forge-rich-text-renderer .content=${content}></forge-rich-text-renderer>`
+      );
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const container = el.shadowRoot?.querySelector('.renderer-content');
+      const link = container?.querySelector('a');
+      const strong = link?.querySelector('strong');
+      expect(link).to.exist;
+      expect(strong).to.exist;
+      expect(strong?.textContent).to.equal('Bold link');
+    });
+  });
+
+  describe('Text Alignment', () => {
+    it('should render left-aligned paragraph', async () => {
+      const content = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            attrs: { textAlign: 'left' },
+            content: [{ type: 'text', text: 'Left aligned' }]
+          }
+        ]
+      };
+
+      const el = await fixture<RichTextRendererComponent>(
+        html`<forge-rich-text-renderer .content=${content}></forge-rich-text-renderer>`
+      );
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const container = el.shadowRoot?.querySelector('.renderer-content');
+      const paragraph = container?.querySelector('p');
+      expect(paragraph).to.exist;
+      expect(paragraph?.style.textAlign).to.equal('left');
+    });
+
+    it('should render center-aligned paragraph', async () => {
+      const content = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            attrs: { textAlign: 'center' },
+            content: [{ type: 'text', text: 'Centered' }]
+          }
+        ]
+      };
+
+      const el = await fixture<RichTextRendererComponent>(
+        html`<forge-rich-text-renderer .content=${content}></forge-rich-text-renderer>`
+      );
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const container = el.shadowRoot?.querySelector('.renderer-content');
+      const paragraph = container?.querySelector('p');
+      expect(paragraph).to.exist;
+      expect(paragraph?.style.textAlign).to.equal('center');
+    });
+
+    it('should render right-aligned paragraph', async () => {
+      const content = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            attrs: { textAlign: 'right' },
+            content: [{ type: 'text', text: 'Right aligned' }]
+          }
+        ]
+      };
+
+      const el = await fixture<RichTextRendererComponent>(
+        html`<forge-rich-text-renderer .content=${content}></forge-rich-text-renderer>`
+      );
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const container = el.shadowRoot?.querySelector('.renderer-content');
+      const paragraph = container?.querySelector('p');
+      expect(paragraph).to.exist;
+      expect(paragraph?.style.textAlign).to.equal('right');
+    });
+
+    it('should render justified paragraph', async () => {
+      const content = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            attrs: { textAlign: 'justify' },
+            content: [{ type: 'text', text: 'Justified text' }]
+          }
+        ]
+      };
+
+      const el = await fixture<RichTextRendererComponent>(
+        html`<forge-rich-text-renderer .content=${content}></forge-rich-text-renderer>`
+      );
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const container = el.shadowRoot?.querySelector('.renderer-content');
+      const paragraph = container?.querySelector('p');
+      expect(paragraph).to.exist;
+      expect(paragraph?.style.textAlign).to.equal('justify');
+    });
+  });
+
+  describe('Complex Content', () => {
+    it('should render mixed content with all features', async () => {
+      const content = {
+        type: 'doc',
+        content: [
+          {
+            type: 'heading',
+            attrs: { level: 1 },
+            content: [{ type: 'text', text: 'Document Title' }]
+          },
+          {
+            type: 'paragraph',
+            content: [
+              { type: 'text', text: 'This is ' },
+              { type: 'text', text: 'bold', marks: [{ type: 'bold' }] },
+              { type: 'text', text: ' and ' },
+              { type: 'text', text: 'italic', marks: [{ type: 'italic' }] },
+              { type: 'text', text: ' text.' }
+            ]
+          },
+          {
+            type: 'bulletList',
+            content: [
+              {
+                type: 'listItem',
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [{ type: 'text', text: 'First item' }]
+                  }
+                ]
+              },
+              {
+                type: 'listItem',
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [{ type: 'text', text: 'Second item' }]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            type: 'paragraph',
+            content: [
+              { type: 'text', text: 'Visit ' },
+              {
+                type: 'text',
+                text: 'our website',
+                marks: [{ type: 'link', attrs: { href: 'https://example.com' } }]
+              }
+            ]
+          }
+        ]
+      };
+
+      const el = await fixture<RichTextRendererComponent>(
+        html`<forge-rich-text-renderer .content=${content}></forge-rich-text-renderer>`
+      );
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const container = el.shadowRoot?.querySelector('.renderer-content');
+      expect(container?.querySelector('h1')).to.exist;
+      expect(container?.querySelector('strong')).to.exist;
+      expect(container?.querySelector('em')).to.exist;
+      expect(container?.querySelector('ul')).to.exist;
+      expect(container?.querySelector('a')).to.exist;
+    });
+
+    it('should handle nested formatting', async () => {
+      const content = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: 'Bold, italic, and underlined',
+                marks: [{ type: 'bold' }, { type: 'italic' }, { type: 'underline' }]
+              }
+            ]
+          }
+        ]
+      };
+
+      const el = await fixture<RichTextRendererComponent>(
+        html`<forge-rich-text-renderer .content=${content}></forge-rich-text-renderer>`
+      );
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const container = el.shadowRoot?.querySelector('.renderer-content');
+      expect(container?.querySelector('strong')).to.exist;
+      expect(container?.querySelector('em')).to.exist;
+      expect(container?.querySelector('u')).to.exist;
+    });
+  });
+});


### PR DESCRIPTION
## Part 6 / 10 Rich Text Editor Version 1.0
PRs are split to provide easily digestible review of the Rich Text Editor

## What was added
Adds the read-only renderer component and output format tests:
- forge-rich-text-renderer: standalone component for displaying saved editor content without an editable surface
- Tests for markdown serialization (markdown-serializer from PR1), HTML/JSON output methods, and renderer rendering

## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: Partially (storybook added in PR10)
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The renderer is the read-only counterpart to forge-rich-text-editor. It accepts ProseMirror JSON content and renders it as styled HTML. This PR also completes the test coverage for the markdown serializer and output methods introduced earlier in the series.